### PR TITLE
Fix: Redirects to Pathnames Using Vercel JSON

### DIFF
--- a/commissions/index.html
+++ b/commissions/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#29242a" />
+    <meta name="description" content="Portfolio and Commissions info for abstract art and media" />
+    <meta name="keywords" content="art, abstract, digital art, Procreate, portfolio, commissions, glitch art" />
+    <meta name="author" content="ZDA" />
+    <meta name="application" content="ZDA Website" />
+    <meta name="robots" content="nofollow, max-snippet:148, noimageindex" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <a rel="me" href="https://ohai.social/@ZeroDayAnubis" style="display: none">Mastodon</a>
+    <title>ZeroDayAnubis - Abstract Media Creator</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#29242a" />
+    <meta name="description" content="Portfolio and Commissions info for abstract art and media" />
+    <meta name="keywords" content="art, abstract, digital art, Procreate, portfolio, commissions, glitch art" />
+    <meta name="author" content="ZDA" />
+    <meta name="application" content="ZDA Website" />
+    <meta name="robots" content="nofollow, max-snippet:148, noimageindex" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <a rel="me" href="https://ohai.social/@ZeroDayAnubis" style="display: none">Mastodon</a>
+    <title>ZeroDayAnubis - Abstract Media Creator</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#29242a" />
+    <meta name="description" content="Portfolio and Commissions info for abstract art and media" />
+    <meta name="keywords" content="art, abstract, digital art, Procreate, portfolio, commissions, glitch art" />
+    <meta name="author" content="ZDA" />
+    <meta name="application" content="ZDA Website" />
+    <meta name="robots" content="nofollow, max-snippet:148, noimageindex" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <link rel="manifest" href="/manifest.json" />
+    <a rel="me" href="https://ohai.social/@ZeroDayAnubis" style="display: none">Mastodon</a>
+    <title>ZeroDayAnubis - Abstract Media Creator</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import {
   slotsReadyAtom,
   waitlistSlotsAtom,
 } from "./states/CommSlotsAtom";
+import { switchPage } from "./Helpers";
 
 type Props = {
   route: string;
@@ -51,6 +52,7 @@ const App = ({ route }: Props) => {
     }, footerDelay);
 
     // Set page to incoming route
+    const currentPath = window.location.href;
     if (route === "portfolio") {
       setPage("Portfolio");
     } else if (route === "commissions") {
@@ -58,7 +60,16 @@ const App = ({ route }: Props) => {
     } else if (route === "examples") {
       setPage("Examples");
     } else {
-      setPage("Home");
+      // Check for direct path in URL and use Hard URL switch to clear sub-domain
+      if (currentPath.toLocaleLowerCase().includes("portfolio")) {
+        switchPage("Portfolio", setPage, true);
+      } else if (currentPath.toLocaleLowerCase().includes("commissions")) {
+        switchPage("Commissions", setPage, true);
+      } else if (currentPath.toLocaleLowerCase().includes("examples")) {
+        switchPage("Examples", setPage, true);
+      } else {
+        setPage("Home");
+      }
     }
 
     // Query Vercel KV Store to get Commissions Slots Info

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,11 +62,11 @@ const App = ({ route }: Props) => {
     } else {
       // Check for direct path in URL and use Hard URL switch to clear sub-domain
       if (currentPath.toLocaleLowerCase().includes("portfolio")) {
-        switchPage("Portfolio", setPage, false); // was true
+        switchPage("Portfolio", setPage, true);
       } else if (currentPath.toLocaleLowerCase().includes("commissions")) {
-        switchPage("Commissions", setPage, false); // was true
+        switchPage("Commissions", setPage, true);
       } else if (currentPath.toLocaleLowerCase().includes("examples")) {
-        switchPage("Examples", setPage, false); // was true
+        switchPage("Examples", setPage, true);
       } else {
         setPage("Home");
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,11 +62,11 @@ const App = ({ route }: Props) => {
     } else {
       // Check for direct path in URL and use Hard URL switch to clear sub-domain
       if (currentPath.toLocaleLowerCase().includes("portfolio")) {
-        switchPage("Portfolio", setPage, true);
+        switchPage("Portfolio", setPage, false); // was true
       } else if (currentPath.toLocaleLowerCase().includes("commissions")) {
-        switchPage("Commissions", setPage, true);
+        switchPage("Commissions", setPage, false); // was true
       } else if (currentPath.toLocaleLowerCase().includes("examples")) {
-        switchPage("Examples", setPage, true);
+        switchPage("Examples", setPage, false); // was true
       } else {
         setPage("Home");
       }

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -23,14 +23,27 @@ export const clickLink = (linkLocation: string, newTab: boolean = true) => {
  * - Setting the global state to new page
  * @param target URL path (Portfolio, Commissions, etc)
  * @param setPage React.useState setter passed in from component
+ * @param hardUrl If true, clear subdomain and go direct to root/target
  */
-export const switchPage = (target: string, setPage: (page: string) => void) => {
+export const switchPage = (
+  target: string,
+  setPage: (page: string) => void,
+  hardUrl: boolean = false
+) => {
   document.body.scrollTop = document.documentElement.scrollTop = 0;
   // Set URL to target without refresh
   if (target === "Home") {
     window.history.replaceState({}, "", "/");
   } else {
-    window.history.replaceState({}, "", "/" + target.toLocaleLowerCase());
+    if (hardUrl) {
+      window.history.replaceState(
+        {},
+        "",
+        "https://www.zerodayanubis.com/" + target.toLocaleLowerCase()
+      );
+    } else {
+      window.history.replaceState({}, "", "/" + target.toLocaleLowerCase());
+    }
   }
   setPage(target);
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,10 @@
 {
   "redirects": [
-    { "source": "/portfolio", "destination": "/index.html", "permanent": true },
+    { "source": "/portfolio", "destination": "https://www.zerodayanubis.com/portfolio" },
     {
       "source": "/commissions",
-      "destination": "/index.html",
-      "permanent": true
+      "destination": "https://www.zerodayanubis.com/commissions"
     },
-    { "source": "/examples", "destination": "/index.html", "permanent": true }
+    { "source": "/examples", "destination": "https://www.zerodayanubis.com/examples" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,10 @@
 {
   "redirects": [
-    { "source": "/portfolio", "destination": "https://portfolio.zerodayanubis.com/" },
+    { "source": "/portfolio", "destination": "/portfolio" },
     {
       "source": "/commissions",
-      "destination": "https://commissions.zerodayanubis.com/"
+      "destination": "/commissions"
     },
-    { "source": "/examples", "destination": "https://examples.zerodayanubis.com/" }
+    { "source": "/examples", "destination": "/examples" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,16 @@
 {
   "redirects": [
-    { "source": "/portfolio", "destination": "/portfolio" },
+    {
+      "source": "/portfolio",
+      "destination": "https://portfolio.zerodayanubis.com/"
+    },
     {
       "source": "/commissions",
-      "destination": "/commissions"
+      "destination": "https://commissions.zerodayanubis.com/"
     },
-    { "source": "/examples", "destination": "/examples" }
+    {
+      "source": "/examples",
+      "destination": "https://examples.zerodayanubis.com/"
+    }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "redirects": [
+    { "source": "/portfolio", "destination": "/index.html", "permanent": true },
+    {
+      "source": "/commissions",
+      "destination": "/index.html",
+      "permanent": true
+    },
+    { "source": "/examples", "destination": "/index.html", "permanent": true }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,10 @@
 {
   "redirects": [
-    { "source": "/portfolio", "destination": "https://www.zerodayanubis.com/portfolio" },
+    { "source": "/portfolio", "destination": "https://portfolio.zerodayanubis.com/" },
     {
       "source": "/commissions",
-      "destination": "https://www.zerodayanubis.com/commissions"
+      "destination": "https://commissions.zerodayanubis.com/"
     },
-    { "source": "/examples", "destination": "https://www.zerodayanubis.com/examples" }
+    { "source": "/examples", "destination": "https://examples.zerodayanubis.com/" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
+import { resolve } from 'path'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        commissions: resolve(__dirname, 'commissions/index.html'),
+        examples: resolve(__dirname, 'examples/index.html'),
+        portfolio: resolve(__dirname, 'portfolio/index.html'),
+      },
+    },
+  },
 })


### PR DESCRIPTION
### Description
------
- Setup Vercel JSON with redirects from pathname to subdomain URLs
  - In App.tsx, this *should* be handled by detecting the target in the href, then do a full hard URL replacement and setPage() properly internally to prevent 404
- Just in case, also did Vite config and folder paths with `index.html` that should redirect to `main.tsx` just like the main index