### PR TITLE
Fix: Force Redirect using wildcard Rewrites in Vercel JSON

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,5 @@
 {
-  "redirects": [
-    {
-      "source": "/portfolio",
-      "destination": "https://portfolio.zerodayanubis.com/"
-    },
-    {
-      "source": "/commissions",
-      "destination": "https://commissions.zerodayanubis.com/"
-    },
-    {
-      "source": "/examples",
-      "destination": "https://examples.zerodayanubis.com/"
-    }
+  "rewrites": [
+    {"source": "/(.*)", "destination": "/"}
   ]
 }


### PR DESCRIPTION
### Description
------
- Use rewrites with wildcard to do redirect in Vercel JSON rather than direct redirect to subdomain
  - From this article: https://dev.to/stanlisberg/resolving-the-vercel-404-page-not-found-error-after-page-refresh-9b9 