### PR TITLE
fix: move Mastodon verification from head to body

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
     <meta name="robots" content="nofollow, max-snippet:148, noimageindex" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <a rel="me" href="https://ohai.social/@ZeroDayAnubis" style="display: none">Mastodon</a>
     <title>ZeroDayAnubis - Abstract Media Creator</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <a rel="me" href="https://ohai.social/@ZeroDayAnubis" style="display: none">Mastodon</a>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
### Description
------
- Moved the Mastodon verification link from the `<head>` to the `<body>`