### PR TITLE
Feat: Hide or Disable Commission Buttons on Closed Status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@emotion/react": "~11.11.1",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -52,6 +52,14 @@ const hideSx = {
   },
 };
 
+/**
+ * Switch style of component depending on theme and whether to hide or not.
+ * @param theme "light"/"dark" value from global atom
+ * @param darkSx the Sx object to use for dark mode
+ * @param lightSx the Sx object to use for light mode
+ * @param hide if true, simply hide the component
+ * @returns 
+ */
 export const switchTheme = (
   theme: string,
   darkSx: object,

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -36,10 +36,33 @@ export const switchPage = (
     window.history.replaceState({}, "", "/");
   } else {
     if (hardUrl) {
-      window.location.replace("https://www.zerodayanubis.com/" + target.toLocaleLowerCase());
+      window.location.replace(
+        "https://www.zerodayanubis.com/" + target.toLocaleLowerCase()
+      );
     } else {
       window.history.replaceState({}, "", "/" + target.toLocaleLowerCase());
     }
   }
   setPage(target);
+};
+
+const hideSx = {
+  ...{
+    display: "none",
+  },
+};
+
+export const switchTheme = (
+  theme: string,
+  darkSx: object,
+  lightSx: object,
+  hide: boolean = false
+) => {
+  if (hide) {
+    return hideSx;
+  } else if (theme === "light") {
+    return lightSx;
+  } else {
+    return darkSx;
+  }
 };

--- a/src/components/sections/BodySection.css
+++ b/src/components/sections/BodySection.css
@@ -11,6 +11,7 @@ img.react-photo-album--photo {
   max-height: 520px;
   transition: opacity 0.2s ease-out;
   object-fit: cover; /* force correct aspect ratio but cropped in */
+  user-select: none;
   &:hover {
     opacity: 0.85;
     transition: opacity 0.2s ease-out;

--- a/src/components/sections/BodySection.tsx
+++ b/src/components/sections/BodySection.tsx
@@ -25,7 +25,7 @@ import StarRoundedIcon from "@mui/icons-material/StarRounded";
 import ClosedCaptionRoundedIcon from "@mui/icons-material/ClosedCaptionRounded";
 import ClosedCaptionDisabledRoundedIcon from "@mui/icons-material/ClosedCaptionDisabledRounded";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
-import { clickLink, switchPage } from "../../Helpers";
+import { clickLink, switchPage, switchTheme } from "../../Helpers";
 import {
   BodyContainerSx,
   BodyHomeHighlightsCardSubtitleDarkSx,
@@ -1237,13 +1237,13 @@ const BodySection = () => {
             </Box>
             <Box>
               <Button
-                disabled={isClosed}
                 onClick={() => clickLink("https://tinyurl.com/ZDACommForm")}
-                sx={
-                  theme === "dark"
-                    ? BodyPortfolioCommBtnDarkSx
-                    : BodyPortfolioCommBtnLightSx
-                }
+                sx={switchTheme(
+                  theme,
+                  BodyPortfolioCommBtnDarkSx,
+                  BodyPortfolioCommBtnLightSx,
+                  isClosed
+                )}
               >
                 <Typography
                   className="Portfolio-Button-Helper"
@@ -1486,13 +1486,13 @@ const BodySection = () => {
                   </Box>
                   <Button
                     endDecorator={<NavigateNextRounded />}
-                    disabled={isClosed}
                     onClick={() => clickLink("https://tinyurl.com/ZDACommForm")}
-                    sx={
-                      theme === "dark"
-                        ? BodyCommsTiersCardBasicBtnDarkSx
-                        : BodyCommsTiersCardBasicBtnLightSx
-                    }
+                    sx={switchTheme(
+                      theme,
+                      BodyCommsTiersCardBasicBtnDarkSx,
+                      BodyCommsTiersCardBasicBtnLightSx,
+                      isClosed
+                    )}
                     aria-description="Opens the request form for Commissions"
                   >
                     Commission Form
@@ -1704,13 +1704,13 @@ const BodySection = () => {
                   </Box>
                   <Button
                     endDecorator={<NavigateNextRounded />}
-                    disabled={isClosed}
                     onClick={() => clickLink("https://tinyurl.com/ZDACommForm")}
-                    sx={
-                      theme === "dark"
-                        ? BodyCommsTiersCardStandardBtnDarkSx
-                        : BodyCommsTiersCardStandardBtnLightSx
-                    }
+                    sx={switchTheme(
+                      theme,
+                      BodyCommsTiersCardStandardBtnDarkSx,
+                      BodyCommsTiersCardStandardBtnLightSx,
+                      isClosed
+                    )}
                     aria-description="Opens the request form for Commissions"
                   >
                     Commission Form
@@ -1953,13 +1953,13 @@ const BodySection = () => {
                   </Box>
                   <Button
                     endDecorator={<NavigateNextRounded />}
-                    disabled={isClosed}
                     onClick={() => clickLink("https://tinyurl.com/ZDACommForm")}
-                    sx={
-                      theme === "dark"
-                        ? BodyCommsTiersCardAbstractifyBtnDarkSx
-                        : BodyCommsTiersCardAbstractifyBtnLightSx
-                    }
+                    sx={switchTheme(
+                      theme,
+                      BodyCommsTiersCardAbstractifyBtnDarkSx,
+                      BodyCommsTiersCardAbstractifyBtnLightSx,
+                      isClosed
+                    )}
                     aria-description="Opens the request form for Commissions"
                   >
                     Commission Form
@@ -2172,13 +2172,13 @@ const BodySection = () => {
                   </Box>
                   <Button
                     endDecorator={<NavigateNextRounded />}
-                    disabled={isClosed}
                     onClick={() => clickLink("https://tinyurl.com/ZDACommForm")}
-                    sx={
-                      theme === "dark"
-                        ? BodyCommsTiersCardPremiumBtnDarkSx
-                        : BodyCommsTiersCardPremiumBtnLightSx
-                    }
+                    sx={switchTheme(
+                      theme,
+                      BodyCommsTiersCardPremiumBtnDarkSx,
+                      BodyCommsTiersCardPremiumBtnLightSx,
+                      isClosed
+                    )}
                     aria-description="Opens the request form for Commissions"
                   >
                     Commission Form

--- a/src/components/sections/TopBanner.tsx
+++ b/src/components/sections/TopBanner.tsx
@@ -21,6 +21,7 @@ import {
   TopBannerButtonGroupSx,
   TopBannerCommButtonDarkHelperSx,
   TopBannerCommButtonDarkSx,
+  TopBannerCommButtonDisabledSx,
   TopBannerCommButtonLightHelperSx,
   TopBannerCommButtonLightSx,
   TopBannerContainerSx,
@@ -43,6 +44,20 @@ const TopBanner = () => {
   const [page, setPage] = useRecoilState(pageAtom);
   const [open, setOpen] = React.useState(false);
   const [isClosed, setClosed] = React.useState(false);
+
+  const determineCommButtonStyle = (
+    darkSx: object,
+    lightSx: object,
+    disabledSx: object
+  ) => {
+    if (isClosed) {
+      return disabledSx;
+    } else if (theme === "light") {
+      return lightSx;
+    } else {
+      return darkSx;
+    }
+  };
 
   const determineGroupButtonStyle = (path: string) => {
     if (page === path) {
@@ -99,11 +114,11 @@ const TopBanner = () => {
             variant="solid"
             disabled={isClosed}
             onClick={() => clickLink("https://tinyurl.com/ZDACommForm")}
-            sx={
-              theme === "dark"
-                ? TopBannerCommButtonDarkSx
-                : TopBannerCommButtonLightSx
-            }
+            sx={determineCommButtonStyle(
+              TopBannerCommButtonDarkSx,
+              TopBannerCommButtonLightSx,
+              TopBannerCommButtonDisabledSx
+            )}
             aria-description="Opens the request form for Commissions"
           >
             <Typography
@@ -116,7 +131,7 @@ const TopBanner = () => {
             >
               Request A Commission
             </Typography>
-            Request A Commission
+            {isClosed ? "Commissions Closed" : "Request A Commission"}
           </Button>
         </Box>
         <Box>

--- a/src/components/sections/TopBannerSx.ts
+++ b/src/components/sections/TopBannerSx.ts
@@ -217,6 +217,22 @@ export const TopBannerCommButtonLightHelperSx = {
   },
 };
 
+export const TopBannerCommButtonDisabledSx = {
+  ...{
+    background:
+      "linear-gradient(69deg,#505050,#707070 30%,#909090 60%,#606060 77%,#707070)",
+    borderRadius: "24px",
+    boxShadow: "0px 0px 1px 1px #afafaf",
+    userSelect: "none",
+    "&:focus": {
+      outline: "none",
+    },
+    "@media (max-width: 340px)": {
+      display: "none",
+    },
+  },
+};
+
 export const TopBannerButtonGroupSx = {
   ...{
     justifyContent: "center",

--- a/src/components/sections/TopInfoSection.css
+++ b/src/components/sections/TopInfoSection.css
@@ -116,3 +116,7 @@ div.MuiBox-root.SpinnerBox::after {
     transform: translate(-50%, -50%) rotate(360deg);
   }
 }
+
+button.MuiButton-root.ButtonRounded {
+  border-radius: 24px; /* force full rounded button for Commission Info btn when isClosed */
+}

--- a/src/components/sections/TopInfoSection.tsx
+++ b/src/components/sections/TopInfoSection.tsx
@@ -78,7 +78,7 @@ import {
   TopInfoTopTypoBoxSx,
 } from "./TopInfoSectionSx";
 import "./TopInfoSection.css";
-import { clickLink, switchPage } from "../../Helpers";
+import { clickLink, switchPage, switchTheme } from "../../Helpers";
 
 const TopInfoSection = () => {
   const theme = useRecoilValue(themeAtom);
@@ -552,19 +552,20 @@ const TopInfoSection = () => {
                   }
                 >
                   <Button
-                    disabled={isClosed}
                     onClick={() => clickLink("https://tinyurl.com/ZDACommForm")}
-                    sx={
-                      theme === "dark"
-                        ? TopInfoCommCardBtnLeftDarkSx
-                        : TopInfoCommCardBtnLeftLightSx
-                    }
+                    sx={switchTheme(
+                      theme,
+                      TopInfoCommCardBtnLeftDarkSx,
+                      TopInfoCommCardBtnLeftLightSx,
+                      isClosed
+                    )}
                     aria-description="Opens the request form for Commissions"
                   >
                     Request A Commission
                   </Button>
-                  <Divider orientation="vertical" />
+                  {!isClosed && <Divider orientation="vertical" />}
                   <Button
+                    className={isClosed ? "ButtonRounded" : "ButtonRegular"}
                     onClick={() =>
                       clickLink("https://tinyurl.com/ZDACommInfo6")
                     }


### PR DESCRIPTION
### Description
------
- Remove ability to 'select' photo album images (and have that ugly blue selection box)
- Add `switchTheme` function to Helpers, which can be used to determine dark/light/hide for components
- NOTE: The TopBanner button uses a special disabled Sx, since hiding ruins the layout
- NOTE: added a special CSS class for the 'Commission Info' button, since hiding the left button causes the button to have a strange left border