### PR TITLE
Fix: Layout Loop Fix and Added Pre-Script Loading Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,20 @@
     <meta name="robots" content="nofollow, max-snippet:148, noimageindex" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="stylesheet" type="text/css" href="/loading.css" />
     <title>ZeroDayAnubis - Abstract Media Creator</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="loadingpage">
+      <div class="SpinnerBox">
+        <span />
+        <span />
+        <span />
+        <span />
+      </div>
+      <span class="loadingspan">Loading ZDA Website...</span>
+    </div>
     <div id="root"></div>
     <a rel="me" href="https://ohai.social/@ZeroDayAnubis" style="display: none">Mastodon</a>
     <script type="module" src="/src/main.tsx"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@emotion/react": "~11.11.1",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --open",
     "start": "vite --open",
+    "hardstart": "vite --open --force",
     "portfolio": "vite --open /portfolio",
     "commissions": "vite --open /commissions",
     "examples": "vite --open /examples",

--- a/public/loading.css
+++ b/public/loading.css
@@ -1,0 +1,89 @@
+div#loadingpage {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #29242a;
+  font-family: Karla, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+  width: 97vw;
+  height: 98vh;
+}
+
+div.SpinnerBox {
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  border-radius: 50%;
+  height: 64px;
+  width: 64px;
+  animation: rotate_3922 1.2s linear infinite;
+  background-color: #9b59b6;
+  background-image: linear-gradient(#9b59b6, #84cdfa, #5ad1cd);
+  z-index: 999;
+
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+div.SpinnerBox span {
+  position: absolute;
+  border-radius: 50%;
+  height: 100%;
+  width: 100%;
+  background-color: #9b59b6;
+  background-image: linear-gradient(#9b59b6, #84cdfa, #5ad1cd);
+}
+
+div.SpinnerBox span:nth-of-type(1) {
+  filter: blur(5px);
+}
+
+div.SpinnerBox span:nth-of-type(2) {
+  filter: blur(10px);
+}
+
+div.SpinnerBox span:nth-of-type(3) {
+  filter: blur(25px);
+}
+
+div.SpinnerBox span:nth-of-type(4) {
+  filter: blur(50px);
+}
+
+div.SpinnerBox::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  background-color: #29242a1a;
+  border: solid 5px #fafafaea;
+  border-radius: 50%;
+}
+
+@keyframes rotate_3922 {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+
+span.loadingspan {
+  position: absolute;
+  top: 60%;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,10 +159,10 @@ const App = ({ route }: Props) => {
   return (
     <>
       <Container className="AppContainer" sx={AppContainerSx}>
-        {bannerReady && page != "Examples" && <TopBanner />}
-        {infoReady && page != "Examples" && <TopInfoSection />}
+        {bannerReady && page !== "Examples" && <TopBanner />}
+        {infoReady && page !== "Examples" && <TopInfoSection />}
         {bodyReady && <BodySection />}
-        {footerReady && page != "Examples" && <FooterSection />}
+        {footerReady && page !== "Examples" && <FooterSection />}
       </Container>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,12 @@ const App = ({ route }: Props) => {
   const slotDelay = 500;
 
   React.useEffect(() => {
+    // Hide the init loading screen
+    const loadingpage = document.querySelector("#loadingpage") as any;
+    if (loadingpage && loadingpage.style) {
+      loadingpage.style = "display: none";
+    }
+
     // Perf Tweak: Load Sections on Delays
     setTimeout(() => {
       setBannerReady(true);

--- a/src/components/sections/BodySection.tsx
+++ b/src/components/sections/BodySection.tsx
@@ -21,10 +21,15 @@ import Lightbox from "yet-another-react-lightbox";
 import { Captions } from "yet-another-react-lightbox/plugins";
 import "yet-another-react-lightbox/styles.css";
 import "yet-another-react-lightbox/plugins/captions.css";
-import StarRoundedIcon from "@mui/icons-material/StarRounded";
-import ClosedCaptionRoundedIcon from "@mui/icons-material/ClosedCaptionRounded";
-import ClosedCaptionDisabledRoundedIcon from "@mui/icons-material/ClosedCaptionDisabledRounded";
-import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import {
+  StarRounded,
+  ClosedCaptionRounded,
+  ClosedCaptionDisabledRounded,
+  CloseRounded,
+  HorizontalRuleRounded,
+  KeyboardBackspaceRounded,
+  NavigateNextRounded,
+} from "@mui/icons-material";
 import { clickLink, switchPage, switchTheme } from "../../Helpers";
 import {
   BodyContainerSx,
@@ -278,11 +283,6 @@ import {
   photos_prints_support,
   photos_socmed,
 } from "./BodySectionPhotos";
-import {
-  HorizontalRuleRounded,
-  KeyboardBackspaceRounded,
-  NavigateNextRounded,
-} from "@mui/icons-material";
 import { commStatusAtom } from "../../states/CommSlotsAtom";
 
 const BodySection = () => {
@@ -377,11 +377,11 @@ const BodySection = () => {
                     }}
                     index={idx_highlights}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_highlights}
                     styles={{
@@ -618,7 +618,7 @@ const BodySection = () => {
                         : BodyHomeSupportCardSubtitleLightSx
                     }
                   >
-                    <StarRoundedIcon
+                    <StarRounded
                       sx={
                         theme === "dark"
                           ? BodyHomeSupportCardStarDarkSx
@@ -626,7 +626,7 @@ const BodySection = () => {
                       }
                     />
                     Any support is greatly appreciated!
-                    <StarRoundedIcon
+                    <StarRounded
                       sx={
                         theme === "dark"
                           ? BodyHomeSupportCardStarDarkSx
@@ -708,11 +708,11 @@ const BodySection = () => {
                     }}
                     index={idx_late2023}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_portfolio_late2023}
                     styles={{
@@ -797,11 +797,11 @@ const BodySection = () => {
                     }}
                     index={idx_late2022}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_portfolio_late2022}
                     styles={{
@@ -886,11 +886,11 @@ const BodySection = () => {
                     }}
                     index={idx_late2021}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_portfolio_late2021}
                     styles={{
@@ -987,11 +987,11 @@ const BodySection = () => {
                     }}
                     index={idx_early2021_pc}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_portfolio_early2021_procreate}
                     styles={{
@@ -1088,11 +1088,11 @@ const BodySection = () => {
                     }}
                     index={idx_early2021_h}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_portfolio_early2021_huion}
                     styles={{
@@ -1189,11 +1189,11 @@ const BodySection = () => {
                     }}
                     index={idx_early2021_p}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_portfolio_early2021_penup}
                     styles={{
@@ -1321,11 +1321,11 @@ const BodySection = () => {
                     }}
                     index={idx_basic}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_comm_basic}
                     styles={{
@@ -1536,11 +1536,11 @@ const BodySection = () => {
                     }}
                     index={idx_standard}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_comm_standard}
                     styles={{
@@ -1756,11 +1756,11 @@ const BodySection = () => {
                     }}
                     index={idx_abstractify}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_comm_abstractify}
                     styles={{
@@ -2003,11 +2003,11 @@ const BodySection = () => {
                     }}
                     index={idx_premium}
                     render={{
-                      iconCaptionsVisible: () => <ClosedCaptionRoundedIcon />,
+                      iconCaptionsVisible: () => <ClosedCaptionRounded />,
                       iconCaptionsHidden: () => (
-                        <ClosedCaptionDisabledRoundedIcon />
+                        <ClosedCaptionDisabledRounded />
                       ),
-                      iconClose: () => <CloseRoundedIcon />,
+                      iconClose: () => <CloseRounded />,
                     }}
                     slides={photos_comm_premium}
                     styles={{
@@ -2265,7 +2265,7 @@ const BodySection = () => {
                         : BodyHomeSupportCardSubtitleLightSx
                     }
                   >
-                    <StarRoundedIcon
+                    <StarRounded
                       sx={
                         theme === "dark"
                           ? BodyHomeSupportCardStarDarkSx
@@ -2273,7 +2273,7 @@ const BodySection = () => {
                       }
                     />
                     Any support is greatly appreciated!
-                    <StarRoundedIcon
+                    <StarRounded
                       sx={
                         theme === "dark"
                           ? BodyHomeSupportCardStarDarkSx

--- a/src/components/sections/BodySectionPhotos.ts
+++ b/src/components/sections/BodySectionPhotos.ts
@@ -34,13 +34,6 @@ export const photos_highlights_srcSet = [
     src: "/assets/highlights_home/album/A_Visual_Violation-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/highlights_home/album/A_Visual_Violation-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "A Visual Violation",
     title: "A Visual Violation",
   },
@@ -48,13 +41,6 @@ export const photos_highlights_srcSet = [
     src: "/assets/highlights_home/album/Kublai_Anubis_02-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/highlights_home/album/Kublai_Anubis_02-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Kublai Anubis 02",
     title: "Kublai Anubis 02",
   },
@@ -62,13 +48,6 @@ export const photos_highlights_srcSet = [
     src: "/assets/highlights_home/album/The_Crux_of_Crisis-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/highlights_home/album/The_Crux_of_Crisis-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "The Crux of Crisis",
     title: "The Crux of Crisis",
   },
@@ -76,13 +55,6 @@ export const photos_highlights_srcSet = [
     src: "/assets/highlights_home/album/Wisps_of_Afterlife-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/highlights_home/album/Wisps_of_Afterlife-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Wisps of Afterlife",
     title: "Wisps of Afterlife",
   },
@@ -200,13 +172,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/Frame_of_Revelation-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/Frame_of_Revelation-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Frame of Revelation",
     title: "Frame of Revelation",
   },
@@ -214,13 +179,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/A_Reflection_of_Self-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/A_Reflection_of_Self-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "A Reflection of Self",
     title: "A Reflection of Self",
   },
@@ -228,13 +186,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/Mark_of_Manifestation-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/Mark_of_Manifestation-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Mark of Manifestation",
     title: "Mark of Manifestation",
   },
@@ -242,13 +193,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/A_System_of_Structure-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/A_System_of_Structure-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "A System of Structure",
     title: "A System of Structure",
   },
@@ -256,13 +200,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/The_Toxic_Descent-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/The_Toxic_Descent-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "The Toxic Descent",
     title: "The Toxic Descent",
   },
@@ -270,13 +207,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/Converging_Spheres-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/Converging_Spheres-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Converging Spheres",
     title: "Converging Spheres",
   },
@@ -284,13 +214,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/Flight_of_Nihility-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/Flight_of_Nihility-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Flight of Nihility",
     title: "Flight of Nihility",
   },
@@ -298,13 +221,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/The_Ephemeral_Eclipse-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/The_Ephemeral_Eclipse-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "The Ephemeral Eclipse",
     title: "The Ephemeral Eclipse",
   },
@@ -312,13 +228,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/Haunted_Tendrils-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/Haunted_Tendrils-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Haunted Tendrils",
     title: "Haunted Tendrils",
   },
@@ -326,13 +235,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/Zygotes_Severed-1000px.jpg",
     width: 1000,
     height: 2167,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/Zygotes_Severed-600px.jpg",
-        width: 600,
-        height: 1300,
-      },
-    ],
     alt: "Zygotes Severed",
     title: "Zygotes Severed",
   },
@@ -340,13 +242,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/Self_Destruct_Sequence-1000px.jpg",
     width: 1000,
     height: 418,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/Self_Destruct_Sequence-600px.jpg",
-        width: 600,
-        height: 251,
-      },
-    ],
     alt: "Self Destruct Sequence",
     title: "Self Destruct Sequence",
   },
@@ -354,13 +249,6 @@ export const photos_portfolio_late2023_srcSet = [
     src: "/assets/portfolio_late2023/album/The_Temple_of_Loss-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2023/album/The_Temple_of_Loss-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "The Temple of Loss",
     title: "The Temple of Loss",
   },
@@ -458,13 +346,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/An_Era_Burned_Away-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/An_Era_Burned_Away-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "An_Era_Burned_Away",
     title: "An_Era_Burned_Away",
   },
@@ -472,13 +353,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Smeared_Bridges-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Smeared_Bridges-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Smeared Bridges",
     title: "Smeared Bridges",
   },
@@ -486,13 +360,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Thing_202305291932-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Thing_202305291932-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Thing_202305291932",
     title: "Thing_202305291932",
   },
@@ -500,13 +367,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Psionic_Twist-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Psionic_Twist-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Psionic Twist",
     title: "Psionic Twist",
   },
@@ -514,13 +374,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/The_Mess_Between-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/The_Mess_Between-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "The Mess Between",
     title: "The Mess Between",
   },
@@ -528,13 +381,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Love_Across_Time-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Love_Across_Time-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Love Across Time",
     title: "Love Across Time",
   },
@@ -542,13 +388,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Was_It_Punishment-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Was_It_Punishment-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Was It Punishment",
     title: "Was It Punishment",
   },
@@ -556,13 +395,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Your_Fear_Regenerates-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Your_Fear_Regenerates-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Your Fear Regenerates",
     title: "Your Fear Regenerates",
   },
@@ -570,13 +402,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Just_A_Flicker-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Just_A_Flicker-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Just A Flicker",
     title: "Just A Flicker",
   },
@@ -584,13 +409,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Retrofuturista-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Retrofuturista-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Retrofuturista",
     title: "Retrofuturista",
   },
@@ -598,13 +416,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Returning_Sublimation-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Returning_Sublimation-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Returning Sublimation",
     title: "Returning Sublimation",
   },
@@ -612,13 +423,6 @@ export const photos_portfolio_late2022_srcSet = [
     src: "/assets/portfolio_late2022/album/Z_Emerges-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2022/album/Z_Emerges-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Z Emerges",
     title: "Z Emerges",
   },
@@ -716,13 +520,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Power_of_Exclusion-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Power_of_Exclusion-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Power of Exclusion",
     title: "Power of Exclusion",
   },
@@ -730,13 +527,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Sakura_Fingers-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Sakura_Fingers-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Sakura Fingers",
     title: "Sakura Fingers",
   },
@@ -744,13 +534,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/A_Toxic_Stitch-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/A_Toxic_Stitch-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "A Toxic Stitch",
     title: "A Toxic Stitch",
   },
@@ -758,13 +541,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Nightrealm-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Nightrealm-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Nightrealm",
     title: "Nightrealm",
   },
@@ -772,13 +548,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Ashes_of_Reverence-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Ashes_of_Reverence-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Ashes of Reverence",
     title: "Ashes of Reverence",
   },
@@ -786,13 +555,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Deconstricted-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Deconstricted-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Deconstricted",
     title: "Deconstricted",
   },
@@ -800,13 +562,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Paralytic_Embrace-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Paralytic_Embrace-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Paralytic Embrace",
     title: "Paralytic Embrace",
   },
@@ -814,13 +569,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Parallel_Abandonment-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Parallel_Abandonment-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Parallel Abandonment",
     title: "Parallel Abandonment",
   },
@@ -828,13 +576,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Impending_Flood-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Impending_Flood-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Impending Flood",
     title: "Impending Flood",
   },
@@ -842,13 +583,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Voidshift_Zero-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Voidshift_Zero-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Voidshift Zero",
     title: "Voidshift Zero",
   },
@@ -856,13 +590,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Forgotten-Displaced-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Forgotten-Displaced-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Forgotten-Displaced",
     title: "Forgotten-Displaced",
   },
@@ -870,13 +597,6 @@ export const photos_portfolio_late2021_srcSet = [
     src: "/assets/portfolio_late2021/album/Ghoul-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_late2021/album/Ghoul-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Ghoul",
     title: "Ghoul",
   },
@@ -918,13 +638,6 @@ export const photos_portfolio_early2021_procreate_srcSet = [
     src: "/assets/portfolio_early2021_procreate/album/First_Doodle_in_Procreate-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_procreate/album/First_Doodle_in_Procreate-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "First Doodle in Procreate",
     title: "First Doodle in Procreate",
   },
@@ -932,13 +645,6 @@ export const photos_portfolio_early2021_procreate_srcSet = [
     src: "/assets/portfolio_early2021_procreate/album/Nothing_Will_Stay-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_procreate/album/Nothing_Will_Stay-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Nothing Will Stay",
     title: "Nothing Will Stay",
   },
@@ -946,13 +652,6 @@ export const photos_portfolio_early2021_procreate_srcSet = [
     src: "/assets/portfolio_early2021_procreate/album/Eroded_Heart-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_procreate/album/Eroded_Heart-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Eroded Heart",
     title: "Eroded Heart",
   },
@@ -960,13 +659,6 @@ export const photos_portfolio_early2021_procreate_srcSet = [
     src: "/assets/portfolio_early2021_procreate/album/Eroded_Chamber-1000px.jpg",
     width: 1000,
     height: 1439,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_procreate/album/Eroded_Chamber-600px.jpg",
-        width: 600,
-        height: 863,
-      },
-    ],
     alt: "Eroded Chamber",
     title: "Eroded Chamber",
   },
@@ -1008,13 +700,6 @@ export const photos_portfolio_early2021_huion_srcSet = [
     src: "/assets/portfolio_early2021_huion/album/HuionSketch_1623481967592-1000px.jpg",
     width: 1000,
     height: 1333,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_huion/album/HuionSketch_1623481967592-600px.jpg",
-        width: 600,
-        height: 800,
-      },
-    ],
     alt: "HuionSketch_1623481967592",
     title: "HuionSketch_1623481967592",
   },
@@ -1022,13 +707,6 @@ export const photos_portfolio_early2021_huion_srcSet = [
     src: "/assets/portfolio_early2021_huion/album/HuionSketch_1625698314399-1000px.jpg",
     width: 1000,
     height: 1333,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_huion/album/HuionSketch_1625698314399-600px.jpg",
-        width: 600,
-        height: 800,
-      },
-    ],
     alt: "HuionSketch_1625698314399",
     title: "HuionSketch_1625698314399",
   },
@@ -1036,13 +714,6 @@ export const photos_portfolio_early2021_huion_srcSet = [
     src: "/assets/portfolio_early2021_huion/album/HuionSketch_1625699078818-1000px.jpg",
     width: 1000,
     height: 1333,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_huion/album/HuionSketch_1625699078818-600px.jpg",
-        width: 600,
-        height: 800,
-      },
-    ],
     alt: "HuionSketch_1625699078818",
     title: "HuionSketch_1625699078818",
   },
@@ -1050,13 +721,6 @@ export const photos_portfolio_early2021_huion_srcSet = [
     src: "/assets/portfolio_early2021_huion/album/HuionSketch_1625704616676-1000px.jpg",
     width: 1000,
     height: 1333,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_huion/album/HuionSketch_1625704616676-600px.jpg",
-        width: 600,
-        height: 800,
-      },
-    ],
     alt: "HuionSketch_1625704616676",
     title: "HuionSketch_1625704616676",
   },
@@ -1154,13 +818,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/penup_20210422_053046-1000px.jpg",
     width: 1000,
     height: 1500,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/penup_20210422_053046-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "penup_20210422_053046",
     title: "penup_20210422_053046",
   },
@@ -1168,13 +825,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210326_003107-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210326_003107-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210326_003107",
     title: "20210326_003107",
   },
@@ -1182,13 +832,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/penup_20210422_055424-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/penup_20210422_055424-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "penup_20210422_055424",
     title: "penup_20210422_055424",
   },
@@ -1196,13 +839,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210202_235729-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210202_235729-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210202_235729",
     title: "20210202_235729",
   },
@@ -1210,13 +846,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210531_091809-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210531_091809-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210531_091809",
     title: "20210531_091809",
   },
@@ -1224,13 +853,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210219_053858-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210219_053858-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210219_053858",
     title: "20210219_053858",
   },
@@ -1238,13 +860,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210308_015320-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210308_015320-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210308_015320",
     title: "20210308_015320",
   },
@@ -1252,13 +867,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210309_005026-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210309_005026-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210309_005026",
     title: "20210309_005026",
   },
@@ -1266,13 +874,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210207_203848-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210207_203848-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210207_203848",
     title: "20210207_203848",
   },
@@ -1280,13 +881,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210203_175221-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210203_175221-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210203_175221",
     title: "20210203_175221",
   },
@@ -1294,13 +888,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210221_021422-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210221_021422-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210221_021422",
     title: "20210221_021422",
   },
@@ -1308,13 +895,6 @@ export const photos_portfolio_early2021_penup_srcSet = [
     src: "/assets/portfolio_early2021_penup/album/20210327_044743-1000px.jpg",
     width: 1080,
     height: 1620,
-    srcSet: [
-      {
-        src: "/assets/portfolio_early2021_penup/album/20210327_044743-600px.jpg",
-        width: 600,
-        height: 900,
-      },
-    ],
     alt: "20210327_044743",
     title: "20210327_044743",
   },
@@ -1370,13 +950,6 @@ export const photos_comm_abstractify_srcSet = [
     src: "/assets/comm_abstractify/album/Broken-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_abstractify/album/Broken-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Broken",
     title: "Broken",
   },
@@ -1384,13 +957,6 @@ export const photos_comm_abstractify_srcSet = [
     src: "/assets/comm_abstractify/album/The_Ghost_Within-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_abstractify/album/The_Ghost_Within-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "The Ghost Within",
     title: "The Ghost Within",
   },
@@ -1398,13 +964,6 @@ export const photos_comm_abstractify_srcSet = [
     src: "/assets/comm_abstractify/album/AEF-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_abstractify/album/AEF-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "All Else Failed",
     title: "All Else Failed",
   },
@@ -1412,13 +971,6 @@ export const photos_comm_abstractify_srcSet = [
     src: "/assets/comm_abstractify/album/SFV-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_abstractify/album/SFV-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Screaming for Vengeance",
     title: "Screaming for Vengeance",
   },
@@ -1426,13 +978,6 @@ export const photos_comm_abstractify_srcSet = [
     src: "/assets/comm_abstractify/album/ORA-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_abstractify/album/ORA-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Oracle",
     title: "Oracle",
   },
@@ -1440,13 +985,6 @@ export const photos_comm_abstractify_srcSet = [
     src: "/assets/comm_abstractify/album/ATS-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_abstractify/album/ATS-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "A Thousand Suns",
     title: "A Thousand Suns",
   },
@@ -1498,13 +1036,6 @@ export const photos_comm_basic_srcSet = [
     src: "/assets/comm_basic/album/QS1-BL-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_basic/album/QS1-BL-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "QS1-BL",
     title: "QS1-BL",
   },
@@ -1512,13 +1043,6 @@ export const photos_comm_basic_srcSet = [
     src: "/assets/comm_basic/album/Tidal_Interference-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_basic/album/Tidal_Interference-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Tidal Interference",
     title: "Tidal Interference",
   },
@@ -1526,13 +1050,6 @@ export const photos_comm_basic_srcSet = [
     src: "/assets/comm_basic/album/QS1-BR-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_basic/album/QS1-BR-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "QS1-BR",
     title: "QS1-BR",
   },
@@ -1540,13 +1057,6 @@ export const photos_comm_basic_srcSet = [
     src: "/assets/comm_basic/album/Indistinguishable_Torment-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_basic/album/Indistinguishable_Torment-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Indistinguishable Torment",
     title: "Indistinguishable Torment",
   },
@@ -1612,13 +1122,6 @@ export const photos_comm_premium_srcSet = [
     src: "/assets/comm_premium/album/The_Crux_of_Crisis-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/comm_premium/album/The_Crux_of_Crisis-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "The Crux of Crisis",
     title: "The Crux of Crisis",
   },
@@ -1626,13 +1129,6 @@ export const photos_comm_premium_srcSet = [
     src: "/assets/comm_premium/album/A_System_of_Structure-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/comm_premium/album/A_System_of_Structure-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "A System of Structure",
     title: "A System of Structure",
   },
@@ -1640,13 +1136,6 @@ export const photos_comm_premium_srcSet = [
     src: "/assets/comm_premium/album/A_Reflection_of_Self-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/comm_premium/album/A_Reflection_of_Self-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "A Reflection of Self",
     title: "A Reflection of Self",
   },
@@ -1654,13 +1143,6 @@ export const photos_comm_premium_srcSet = [
     src: "/assets/comm_premium/album/The_Toxic_Descent-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_premium/album/The_Toxic_Descent-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "The Toxic Descent",
     title: "The Toxic Descent",
   },
@@ -1668,13 +1150,6 @@ export const photos_comm_premium_srcSet = [
     src: "/assets/comm_premium/album/Frame_of_Revelation-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/comm_premium/album/Frame_of_Revelation-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Frame of Revelation",
     title: "Frame of Revelation",
   },
@@ -1682,13 +1157,6 @@ export const photos_comm_premium_srcSet = [
     src: "/assets/comm_premium/album/The_Temple_of_Loss-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_premium/album/The_Temple_of_Loss-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "The Temple of Loss",
     title: "The Temple of Loss",
   },
@@ -1754,13 +1222,6 @@ export const photos_comm_standard_srcSet = [
     src: "/assets/comm_standard/album/Divinity_Ends-1000px.jpg",
     width: 1000,
     height: 2167,
-    srcSet: [
-      {
-        src: "/assets/comm_standard/album/Divinity_Ends-600px.jpg",
-        width: 600,
-        height: 1300,
-      },
-    ],
     alt: "Divinity Ends",
     title: "Divinity Ends",
   },
@@ -1768,13 +1229,6 @@ export const photos_comm_standard_srcSet = [
     src: "/assets/comm_standard/album/Wisps_of_Afterlife-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/comm_standard/album/Wisps_of_Afterlife-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Wisps of Afterlife",
     title: "Wisps of Afterlife",
   },
@@ -1782,13 +1236,6 @@ export const photos_comm_standard_srcSet = [
     src: "/assets/comm_standard/album/Returning_Sublimation-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/comm_standard/album/Returning_Sublimation-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "Returning Sublimation",
     title: "Returning Sublimation",
   },
@@ -1796,13 +1243,6 @@ export const photos_comm_standard_srcSet = [
     src: "/assets/comm_standard/album/The_Chroma_Passage-1000px.jpg",
     width: 1000,
     height: 1414,
-    srcSet: [
-      {
-        src: "/assets/comm_standard/album/The_Chroma_Passage-600px.jpg",
-        width: 600,
-        height: 849,
-      },
-    ],
     alt: "The Chroma Passage",
     title: "The Chroma Passage",
   },
@@ -1810,13 +1250,6 @@ export const photos_comm_standard_srcSet = [
     src: "/assets/comm_standard/album/Passengers-1000px.jpg",
     width: 1000,
     height: 695,
-    srcSet: [
-      {
-        src: "/assets/comm_standard/album/Passengers-600px.jpg",
-        width: 600,
-        height: 417,
-      },
-    ],
     alt: "Passengers",
     title: "Passengers",
   },
@@ -1824,13 +1257,6 @@ export const photos_comm_standard_srcSet = [
     src: "/assets/comm_standard/album/Jack-O-Portal-1000px.jpg",
     width: 1000,
     height: 1000,
-    srcSet: [
-      {
-        src: "/assets/comm_standard/album/Jack-O-Portal-600px.jpg",
-        width: 600,
-        height: 600,
-      },
-    ],
     alt: "Jack-O-Portal",
     title: "Jack-O-Portal",
   },

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,8 @@
 :root {
   /* font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif; */ /* VITE JS ORIG FONT */
   font-family: Karla, system-ui, Avenir, Helvetica, Arial, sans-serif;
-
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #29242a;


### PR DESCRIPTION
### Description
------
- Fix: using proper `{...}` style imports for MUI icons
- Fix: stop the layout loop that was happening for React Photo Album by removing the `srcSet` attribute from the photo arrays
  - NOTE: I used the network throtting feature of Dev Tools to find out that the `size` and `style` attributes kept changing back and forth between the smaller and bigger image for each `<img>` tag
- Feat: added a placeholding loading page directly in the root `index.html` so that a spinner and text are shown on screen before the main script (and dependencies) are loaded