### PR TITLE
Fix: Logo Hover Compatibility with Mobile

### DIFF
--- a/src/components/sections/BodySectionSx.ts
+++ b/src/components/sections/BodySectionSx.ts
@@ -2820,12 +2820,12 @@ export const BodyLogoPageButtonDarkSx = {
     marginBottom: "8px",
     backgroundColor: "#ff006a",
     color: "#fafafafa",
-    transition: "background-color 0.3s ease-out, color 0.3s ease-out",
+    transition: "background-color 0.6s ease-out, color 0.3s ease-out",
     userSelect: "none",
     "&:hover": {
-      backgroundColor: "#aa003a",
-      color: "#09040a",
-      transition: "background-color 0.3s ease-out, color 0.3s ease-out",
+      backgroundColor: "#c955bf",
+      color: "#000000",
+      transition: "background-color 0.6s ease-out, color 0.3s ease-out",
     },
     "&:focus": {
       outline: "none",
@@ -2841,12 +2841,12 @@ export const BodyLogoPageButtonLightSx = {
     marginBottom: "8px",
     backgroundColor: "#eb004e",
     color: "#fafafafa",
-    transition: "background-color 0.3s ease-out, color 0.3s ease-out",
+    transition: "background-color 0.6s ease-out, color 0.3s ease-out",
     userSelect: "none",
     "&:hover": {
-      backgroundColor: "#ff507a",
-      color: "#19141a",
-      transition: "background-color 0.3s ease-out, color 0.3s ease-out",
+      backgroundColor: "#ff557f",
+      color: "#09040a",
+      transition: "background-color 0.6s ease-out, color 0.3s ease-out",
     },
     "&:focus": {
       outline: "none",

--- a/src/components/sections/TopBanner.css
+++ b/src/components/sections/TopBanner.css
@@ -34,9 +34,10 @@ img.ZDA-Logo-TopBanner {
   margin-right: 20px;
   cursor: pointer;
   user-select: none;
-  &:hover {
-    display: none;
-  }
+  /* More precise but less compatible/more buggy */
+  /* &:hover { */
+    /* display: none; */
+  /* } */
 }
 
 img.ZDA-Logo-TopBanner-Hover {
@@ -48,7 +49,19 @@ img.ZDA-Logo-TopBanner-Hover {
   user-select: none;
 }
 
-img.ZDA-Logo-TopBanner:hover + img {
+/* More precise but less compatible/more buggy */
+/* img.ZDA-Logo-TopBanner:hover + img {
+  display: block;
+} */
+
+/* Less precise but more compatible/less buggy */
+div.Logo-Box:hover img.ZDA-Logo-TopBanner,
+div.Logo-Box:active img.ZDA-Logo-TopBanner {
+  display: none;
+}
+
+div.Logo-Box:hover img.ZDA-Logo-TopBanner-Hover,
+div.Logo-Box:active img.ZDA-Logo-TopBanner-Hover {
   display: block;
 }
 

--- a/src/components/sections/TopBanner.tsx
+++ b/src/components/sections/TopBanner.tsx
@@ -99,12 +99,14 @@ const TopBanner = () => {
               className="ZDA-Logo-TopBanner"
               alt="ZDA"
               onClick={() => switchPage("Logo", setPage)}
+              onTouchEnd={() => switchPage("Logo", setPage)}
             />
             <img
               src={zdaHoverLogo}
               className="ZDA-Logo-TopBanner-Hover"
               alt="ZDA"
               onClick={() => switchPage("Logo", setPage)}
+              onTouchEnd={() => switchPage("Logo", setPage)}
             />
           </div>
         </Box>
@@ -132,12 +134,14 @@ const TopBanner = () => {
               className="ZDA-Logo-TopBanner"
               alt="ZDA"
               onClick={() => switchPage("Logo", setPage)}
+              onTouchEnd={() => switchPage("Logo", setPage)}
             />
             <img
               src={zdaHoverLogo}
               className="ZDA-Logo-TopBanner-Hover"
               alt="ZDA"
               onClick={() => switchPage("Logo", setPage)}
+              onTouchEnd={() => switchPage("Logo", setPage)}
             />
           </div>
           <HamburgerMenu open={open} setOpen={setOpen} />


### PR DESCRIPTION
### Description
------
- Safari has issues rendering the 'clip-path' in SVG (may try a fix later, just doing `-webkit-clip-path` did NOT work), and also had issues with the hover and touch target for the logo in TopBanner
- Reverted back to less precise but also less buggy hover implementation for TopBanner logo
- Added `onTouchEnd` event to try to better capture clicks on mobile (since onClick was not always registering)