### PR TITLE
Fix: Full Height Logo Page and Fix Small Height Squish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@emotion/react": "~11.11.1",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/components/sections/BodySectionSx.ts
+++ b/src/components/sections/BodySectionSx.ts
@@ -2734,6 +2734,10 @@ export const BodyLogoPageBoxSx = {
     justifyContent: "center",
     alignItems: "center",
     width: "100%",
+    height: "100vh",
+    "@media (max-height: 550px)": {
+      height: "100%", // prevent squish and allow scroll on small screens
+    },
   },
 };
 
@@ -2894,6 +2898,9 @@ export const BodyLogoPageHiddenTextBoxSx = {
     "@media (max-width: 1000px)": {
       right: "auto",
     },
+    "@media (max-height: 540px)": {
+      position: "relative", // prevents squish and overlap on other elems
+    }
   },
 };
 


### PR DESCRIPTION
### Description
------
Fixes for Logo Page:
- Use 100vh height on most screens and 100% height on small height screens
- Prevent squish overlap of hidden text by using position relative on small height screens