### PR TITLE
Fix: Scroll To Top disappearing when going to LogoPage

### DIFF
--- a/src/components/JumpToTop.tsx
+++ b/src/components/JumpToTop.tsx
@@ -32,13 +32,11 @@ const JumpToTop = () => {
 
   React.useEffect(() => {
     setFABVisibility(false);
-    if (!window.onscroll) {
-      // Add debounced handler to check scroll position
-      window.onscroll = () => {
-        debouncedScroll();
-      };
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Add debounced handler to check scroll position
+    window.onscroll = () => {
+      debouncedScroll();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/pages/ExamplesPage.tsx
+++ b/src/pages/ExamplesPage.tsx
@@ -8,9 +8,14 @@ import {
   photosExamplesVectorizeThumbnail,
 } from "../thumbnailInfo";
 import ZDAButton from "../components/ZDAButton";
+import { switchPage } from "../helpers";
+import { useRecoilState } from "recoil";
+import { pageAtom } from "../states/pageAtom";
 
 const ExamplesPage = () => {
   const currentYear = new Date().getFullYear();
+  const [, setPage] = useRecoilState(pageAtom);
+
   React.useEffect(() => {
     // Hide the init loading screen
     const loadingpage = document.querySelector("#loadingpage") as any;
@@ -147,13 +152,13 @@ const ExamplesPage = () => {
       </div>
       <div className="ZDAButton-container my-8">
         <ZDAButton
-          clickCallback={() => window.location.replace("/")}
+          clickCallback={() => switchPage("Home", setPage)}
           leftIcon={leftArrowMdIcon}
           textContent="Go Back"
           variant="mobile-grid"
         />
         <ZDAButton
-          clickCallback={() => window.location.replace("/")}
+          clickCallback={() => switchPage("Home", setPage)}
           leftIcon={leftArrowMdIcon}
           textContent="Go Back"
           variant="grid"

--- a/src/pages/LogoPage.tsx
+++ b/src/pages/LogoPage.tsx
@@ -26,6 +26,12 @@ const LogoPage = () => {
   const [currentColor, setColor] = React.useState(colorMap[0]);
 
   React.useEffect(() => {
+    // Hide the init loading screen
+    const loadingpage = document.querySelector("#loadingpage") as any;
+    if (loadingpage && loadingpage.style) {
+      loadingpage.style = "display: none";
+    }
+
     // Randomize color used for long text logo
     const randomColor = colorMap[Math.floor(Math.random() * colorMap.length)];
     setColor(randomColor);


### PR DESCRIPTION
## Description
Closes #43 by addressing 3 small issues that fix the overall scroll to top issue:
- LogoPage was missing the loadingpage hide logic
- ExamplesPage, on clicking Go Back, was doing a naive hard route to root url (window.location.replace("/")) rather than using the existing switchPage() logic from LogoPage
- The IF statement in JumpToTop, to check for existence of `window.onscroll` event handler, was causing issues since it thought the handler already existed, and so switching pages with switchPage (on "Home") was negating the nested call to the debouncer. Removing the existence check does not seem to cause any performance issues.