### PR TITLE
Feat: Add Clickability to Examples Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "dependencies": {
         "@emotion/react": "~11.11.3",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.0.5",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/pages/ExamplesPage.tsx
+++ b/src/pages/ExamplesPage.tsx
@@ -11,10 +11,26 @@ import ZDAButton from "../components/ZDAButton";
 import { switchPage } from "../helpers";
 import { useRecoilState } from "recoil";
 import { pageAtom } from "../states/pageAtom";
+import Lightbox from "yet-another-react-lightbox";
+import { Captions } from "yet-another-react-lightbox/plugins";
+import "yet-another-react-lightbox/styles.css";
+import "yet-another-react-lightbox/plugins/captions.css";
+import { MdClosedCaption, MdClosedCaptionDisabled } from "react-icons/md";
+import { IoMdCloseCircle } from "react-icons/io";
+import {
+  photosCommissionsAbstractify,
+  photosCommissionsCoalesce,
+  photosCommissionsVectorize,
+} from "../lightboxInfo";
 
 const ExamplesPage = () => {
   const currentYear = new Date().getFullYear();
   const [, setPage] = useRecoilState(pageAtom);
+  const [idx_abstractify, setIdx_abstractify] = React.useState(-1);
+  const [idx_vectorize, setIdx_vectorize] = React.useState(-1);
+  const [idx_coalesce, setIdx_coalesce] = React.useState(-1);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const captionsRef = React.useRef(null) as any;
 
   React.useEffect(() => {
     // Hide the init loading screen
@@ -45,10 +61,11 @@ const ExamplesPage = () => {
           <div className="examples-page-card-content mx-4 my-6 sm:my-8 flex flex-col justify-between items-center">
             <div className="examples-page-card-img-container">
               <img
+                onClick={() => setIdx_abstractify(0)}
                 src={photosExamplesAbstractifyThumbnail[0].src}
                 alt={photosExamplesAbstractifyThumbnail[0].alt}
                 title={photosExamplesAbstractifyThumbnail[0].title}
-                className="examples-img01 z-10 aspect-[9/13] h-full w-full sm:w-48 lg:w-56 xl:w-60 2xl:w-72 3xl:w-[26rem] my-8 object-cover object-left-bottom rounded-md border-solid border dark:border-2 border-transparent select-none"
+                className="examples-img01 z-10 aspect-[9/13] h-full w-full sm:w-48 lg:w-56 xl:w-60 2xl:w-72 3xl:w-[26rem] my-8 object-cover object-left-bottom rounded-md border-solid border dark:border-2 border-transparent brightness-100 motion-safe:transition-all motion-safe:duration-300 ease-out hover:brightness-[1.03] hover:border-neutral-600/40 dark:hover:border-neutral-500/60 select-none cursor-pointer"
               />
             </div>
             <div className="examples-page-card-description my-4 text-sm lg:text-base">
@@ -56,6 +73,10 @@ const ExamplesPage = () => {
                 <li>Made in Procreate</li>
                 <li>Transform idea into digital abstract painting</li>
                 <li>Ready in 2-3 days</li>
+                <li className="font-light tracking-tight italic mt-2">
+                  (Click image for <br className="hidden md:block lg:hidden" />
+                  more examples)
+                </li>
               </ul>
             </div>
           </div>
@@ -69,6 +90,50 @@ const ExamplesPage = () => {
             </span>
           </div>
         </div>
+        <Lightbox
+          plugins={[Captions]}
+          captions={{
+            ref: captionsRef,
+            showToggle: true,
+            descriptionTextAlign: "center",
+          }}
+          on={{
+            click: () => {
+              (captionsRef.current?.visible
+                ? captionsRef.current?.hide
+                : captionsRef.current?.show)?.();
+            },
+          }}
+          index={idx_abstractify}
+          render={{
+            iconCaptionsVisible: () => <MdClosedCaption size={28} />,
+            iconCaptionsHidden: () => <MdClosedCaptionDisabled size={28} />,
+            iconClose: () => <IoMdCloseCircle size={28} />,
+          }}
+          slides={photosCommissionsAbstractify}
+          styles={{
+            container: {
+              backdropFilter: "blur(16px)",
+              backgroundColor: "rgba(0,0,0,0.8)",
+            },
+            captionsTitle: {
+              fontSize: "16px",
+              fontWeight: "300",
+            },
+            captionsTitleContainer: {
+              height: "46px",
+              position: "absolute",
+              bottom: "0",
+              left: "0",
+              top: "auto",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            },
+          }}
+          open={idx_abstractify >= 0}
+          close={() => setIdx_abstractify(-1)}
+        />
         <div className="examples-page-card w-full h-full mx-2 my-4 rounded-xl border border-gray-200 dark:border-neutral-800 select-none">
           <div className="examples-page-card-title-container flex flex-col justify-center items-center my-2 sm:my-4">
             <span className="examples-page-card-title flex text-xl font-urbanist font-normal tracking-wider select-none">
@@ -79,10 +144,11 @@ const ExamplesPage = () => {
           <div className="examples-page-card-content mx-4 my-6 sm:my-8 flex flex-col justify-between items-center">
             <div className="examples-page-card-img-container">
               <img
+                onClick={() => setIdx_vectorize(0)}
                 src={photosExamplesVectorizeThumbnail[0].src}
                 alt={photosExamplesVectorizeThumbnail[0].alt}
                 title={photosExamplesVectorizeThumbnail[0].title}
-                className="examples-img02 z-10 aspect-[9/13] h-full w-full sm:w-48 lg:w-56 xl:w-60 2xl:w-72 3xl:w-[26rem] my-8 object-cover object-center rounded-md border-solid border dark:border-2 border-transparent select-none"
+                className="examples-img02 z-10 aspect-[9/13] h-full w-full sm:w-48 lg:w-56 xl:w-60 2xl:w-72 3xl:w-[26rem] my-8 object-cover object-center rounded-md border-solid border dark:border-2 border-transparent brightness-100 motion-safe:transition-all motion-safe:duration-300 ease-out hover:brightness-[1.03] hover:border-neutral-600/40 dark:hover:border-neutral-500/60 select-none cursor-pointer"
               />
             </div>
             <div className="examples-page-card-description my-4 text-sm lg:text-base">
@@ -90,6 +156,10 @@ const ExamplesPage = () => {
                 <li>Made in Inkscape</li>
                 <li>Translate idea into vector art/logo/design</li>
                 <li>Ready in 2-3 days</li>
+                <li className="font-light tracking-tight italic mt-2">
+                  (Click image for <br className="hidden md:block lg:hidden" />
+                  more examples)
+                </li>
               </ul>
             </div>
           </div>
@@ -103,6 +173,50 @@ const ExamplesPage = () => {
             </span>
           </div>
         </div>
+        <Lightbox
+          plugins={[Captions]}
+          captions={{
+            ref: captionsRef,
+            showToggle: true,
+            descriptionTextAlign: "center",
+          }}
+          on={{
+            click: () => {
+              (captionsRef.current?.visible
+                ? captionsRef.current?.hide
+                : captionsRef.current?.show)?.();
+            },
+          }}
+          index={idx_vectorize}
+          render={{
+            iconCaptionsVisible: () => <MdClosedCaption size={28} />,
+            iconCaptionsHidden: () => <MdClosedCaptionDisabled size={28} />,
+            iconClose: () => <IoMdCloseCircle size={28} />,
+          }}
+          slides={photosCommissionsVectorize}
+          styles={{
+            container: {
+              backdropFilter: "blur(16px)",
+              backgroundColor: "rgba(0,0,0,0.8)",
+            },
+            captionsTitle: {
+              fontSize: "16px",
+              fontWeight: "300",
+            },
+            captionsTitleContainer: {
+              height: "46px",
+              position: "absolute",
+              bottom: "0",
+              left: "0",
+              top: "auto",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            },
+          }}
+          open={idx_vectorize >= 0}
+          close={() => setIdx_vectorize(-1)}
+        />
         <div className="examples-page-card w-full h-full mx-2 my-4 rounded-xl border border-gray-200 dark:border-neutral-800 select-none">
           <div className="examples-page-card-title-container flex flex-col justify-center items-center my-2 sm:my-4">
             <span className="examples-page-card-title flex text-xl font-urbanist font-normal tracking-wider select-none">
@@ -113,10 +227,11 @@ const ExamplesPage = () => {
           <div className="examples-page-card-content mx-4 my-6 sm:my-8 flex flex-col justify-between items-center">
             <div className="examples-page-card-img-container">
               <img
+                onClick={() => setIdx_coalesce(0)}
                 src={photosExamplesCoalesceThumbnail[0].src}
                 alt={photosExamplesCoalesceThumbnail[0].alt}
                 title={photosExamplesCoalesceThumbnail[0].title}
-                className="examples-img03 z-10 aspect-[9/13] h-full w-full sm:w-48 lg:w-56 xl:w-60 2xl:w-72 3xl:w-[26rem] my-8 object-cover object-center rounded-md border-solid border dark:border-2 border-transparent select-none"
+                className="examples-img03 z-10 aspect-[9/13] h-full w-full sm:w-48 lg:w-56 xl:w-60 2xl:w-72 3xl:w-[26rem] my-8 object-cover object-center rounded-md border-solid border dark:border-2 border-transparent brightness-100 motion-safe:transition-all motion-safe:duration-300 ease-out hover:brightness-[1.03] hover:border-neutral-600/40 dark:hover:border-neutral-500/60 select-none cursor-pointer"
               />
             </div>
             <div className="examples-page-card-description my-4 text-sm lg:text-base">
@@ -127,6 +242,10 @@ const ExamplesPage = () => {
                 </li>
                 <li>Fusion of abstract painting and vector art</li>
                 <li>Ready in 3-5 days</li>
+                <li className="font-light tracking-tight italic mt-2">
+                  (Click image for <br className="hidden md:block lg:hidden" />
+                  more examples)
+                </li>
               </ul>
             </div>
           </div>
@@ -140,6 +259,50 @@ const ExamplesPage = () => {
             </span>
           </div>
         </div>
+        <Lightbox
+          plugins={[Captions]}
+          captions={{
+            ref: captionsRef,
+            showToggle: true,
+            descriptionTextAlign: "center",
+          }}
+          on={{
+            click: () => {
+              (captionsRef.current?.visible
+                ? captionsRef.current?.hide
+                : captionsRef.current?.show)?.();
+            },
+          }}
+          index={idx_coalesce}
+          render={{
+            iconCaptionsVisible: () => <MdClosedCaption size={28} />,
+            iconCaptionsHidden: () => <MdClosedCaptionDisabled size={28} />,
+            iconClose: () => <IoMdCloseCircle size={28} />,
+          }}
+          slides={photosCommissionsCoalesce}
+          styles={{
+            container: {
+              backdropFilter: "blur(16px)",
+              backgroundColor: "rgba(0,0,0,0.8)",
+            },
+            captionsTitle: {
+              fontSize: "16px",
+              fontWeight: "300",
+            },
+            captionsTitleContainer: {
+              height: "46px",
+              position: "absolute",
+              bottom: "0",
+              left: "0",
+              top: "auto",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            },
+          }}
+          open={idx_coalesce >= 0}
+          close={() => setIdx_coalesce(-1)}
+        />
         <a
           href="https://www.zda.works/"
           className="md:col-span-3 pt-4 text-sm text-gray-700 dark:text-gray-400 select-none"


### PR DESCRIPTION
### Description

- Per issue #51 , added Lightbox from Commissions Page to Examples Page, and carried over hover styles to the img elements, and tweaked brightness to be full at rest.
----
Resolves #51 