### PR TITLE
Feat: Router Refactor and Form, Info, and Privacy Routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@emotion/react": "~11.11.3",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/RedirectStub.tsx
+++ b/src/RedirectStub.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import ThemeMenu from "./components/ThemeMenu";
+import { redirectToLink } from "./helpers";
+
+type props = {
+  redirectPath: string;
+};
+
+const RedirectStub = ({ redirectPath }: props) => {
+  React.useEffect(() => {
+    // Hide the init loading screen
+    const loadingpage = document.querySelector("#loadingpage") as any;
+    if (loadingpage && loadingpage.style) {
+      loadingpage.style = "display: none";
+    }
+
+    // Do redirect from route
+    redirectToLink(redirectPath);
+  }, []);
+
+  return (
+    <div className="flex justify-center w-full h-full bg-zdaBG-light dark:bg-zdaBG-dark">
+      {/* NOTE: ThemeMenu needed here to detect theme separately, since this page bypasses App */}
+      <div className="cursor-pointer focus-visible:outline-none absolute top-0 left-1/2 -translate-x-2/4 mr-0 mt-3 lg:left-auto lg:translate-x-0 lg:right-0 lg:mr-6">
+        <ThemeMenu />
+      </div>
+      <div className="flex flex-col sm:flex-row items-center justify-center">
+        <span className="inline-flex m-6 3xl:m-10 4xl:m-12 4k:m-16 font-semibold text-xl 3xl:text-2xl 4xl:text-3xl 4k:text-[42px] text-gray-600 dark:text-gray-300 pointer-events-none select-none">
+          Redirecting...
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default RedirectStub;

--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -24,6 +24,16 @@ import zerodayanubis_dark from "/zerodayanubis_dark.svg";
 import zerodayanubis_light from "/zerodayanubis_light.svg";
 import { altLongTextLogo } from "../AltText";
 import ZDAButton from "./ZDAButton";
+import {
+  bskyLink,
+  caraLink,
+  igLink,
+  kofiLink,
+  payPalLink,
+  printShopLink,
+  threadsLink,
+  venmoLink,
+} from "../links";
 
 type props = {
   open: boolean;
@@ -123,7 +133,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
             <Box className="flex flex-col flex-wrap content-center items-center justify-center gap-[6px]">
               <ZDAButton
                 clickCallback={() => {
-                  clickLink("https://bsky.app/profile/zerodayanubis.com");
+                  clickLink(bskyLink);
                   setOpen(false);
                 }}
                 leftIcon={bskyIcon}
@@ -133,9 +143,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
               />
               <ZDAButton
                 clickCallback={() => {
-                  clickLink(
-                    "https://instagram.com/zerodayanubis?igshid=OGQ5ZDc2ODk2ZA=="
-                  );
+                  clickLink(igLink);
                   setOpen(false);
                 }}
                 leftIcon={igIcon}
@@ -145,7 +153,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
               />
               <ZDAButton
                 clickCallback={() => {
-                  clickLink("https://www.threads.net/@zerodayanubis");
+                  clickLink(threadsLink);
                   setOpen(false);
                 }}
                 leftIcon={threadsIcon}
@@ -155,7 +163,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
               />
               <ZDAButton
                 clickCallback={() => {
-                  clickLink("https://tinyurl.com/ZDACara");
+                  clickLink(caraLink);
                   setOpen(false);
                 }}
                 leftIcon={caraIcon}
@@ -170,7 +178,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
             <Box className="flex flex-col flex-wrap content-center items-center justify-center gap-[6px]">
               <ZDAButton
                 clickCallback={() => {
-                  clickLink("https://tinyurl.com/ZDAPrints");
+                  clickLink(printShopLink);
                   setOpen(false);
                 }}
                 leftIcon={printShopIcon}
@@ -180,7 +188,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
               />
               <ZDAButton
                 clickCallback={() => {
-                  clickLink("https://ko-fi.com/zerodayanubis");
+                  clickLink(kofiLink);
                   setOpen(false);
                 }}
                 leftIcon={kofiIcon}
@@ -190,7 +198,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
               />
               <ZDAButton
                 clickCallback={() => {
-                  clickLink("https://www.paypal.com/ncp/payment/AGHU59JTKAC66");
+                  clickLink(payPalLink);
                   setOpen(false);
                 }}
                 leftIcon={payPalIcon}
@@ -200,7 +208,7 @@ const HamburgerMenu = ({ open, setOpen }: props) => {
               />
               <ZDAButton
                 clickCallback={() => {
-                  clickLink("https://account.venmo.com/u/somgye");
+                  clickLink(venmoLink);
                   setOpen(false);
                 }}
                 leftIcon={paymentIcon}

--- a/src/components/PagePromos.tsx
+++ b/src/components/PagePromos.tsx
@@ -1,6 +1,16 @@
 import * as React from "react";
 import ZDAButton from "./ZDAButton";
 import { clickLink } from "../helpers";
+import {
+  bskyLink,
+  caraLink,
+  igLink,
+  kofiLink,
+  payPalLink,
+  printShopLink,
+  threadsLink,
+  venmoLink,
+} from "../links";
 
 const PagePromos = () => {
   return (
@@ -15,13 +25,13 @@ const PagePromos = () => {
             Get art prints, posters, stickers, cards and more:
           </span>
           <ZDAButton
-            clickCallback={() => clickLink("https://tinyurl.com/ZDAPrints")}
+            clickCallback={() => clickLink(printShopLink)}
             textContent="Print Shop"
             tight
             variant="mobile-neutral"
           />
           <ZDAButton
-            clickCallback={() => clickLink("https://tinyurl.com/ZDAPrints")}
+            clickCallback={() => clickLink(printShopLink)}
             textContent="Print Shop"
             tight
             variant="neutral"
@@ -36,13 +46,13 @@ const PagePromos = () => {
             Download high-quality versions of my art for free:
           </p>
           <ZDAButton
-            clickCallback={() => clickLink("https://ko-fi.com/zerodayanubis")}
+            clickCallback={() => clickLink(kofiLink)}
             textContent="Ko-fi"
             tight
             variant="mobile-neutral"
           />
           <ZDAButton
-            clickCallback={() => clickLink("https://ko-fi.com/zerodayanubis")}
+            clickCallback={() => clickLink(kofiLink)}
             textContent="Ko-fi"
             tight
             variant="neutral"
@@ -58,29 +68,25 @@ const PagePromos = () => {
           </p>
           <div className="promo-button-container flex flex-col justify-center items-center gap-1">
             <ZDAButton
-              clickCallback={() => clickLink("https://www.paypal.com/ncp/payment/AGHU59JTKAC66")}
+              clickCallback={() => clickLink(payPalLink)}
               textContent="PayPal"
               tight
               variant="mobile-neutral"
             />
             <ZDAButton
-              clickCallback={() => clickLink("https://www.paypal.com/ncp/payment/AGHU59JTKAC66")}
+              clickCallback={() => clickLink(payPalLink)}
               textContent="PayPal"
               tight
               variant="neutral"
             />
             <ZDAButton
-              clickCallback={() =>
-                clickLink("https://account.venmo.com/u/somgye")
-              }
+              clickCallback={() => clickLink(venmoLink)}
               textContent="Venmo"
               tight
               variant="mobile-neutral"
             />
             <ZDAButton
-              clickCallback={() =>
-                clickLink("https://account.venmo.com/u/somgye")
-              }
+              clickCallback={() => clickLink(venmoLink)}
               textContent="Venmo"
               tight
               variant="neutral"
@@ -97,65 +103,49 @@ const PagePromos = () => {
           </p>
           <div className="promo-button-container flex flex-col justify-center items-center gap-1">
             <ZDAButton
-              clickCallback={() =>
-                clickLink("https://bsky.app/profile/zerodayanubis.com")
-              }
+              clickCallback={() => clickLink(bskyLink)}
               textContent="Bluesky"
               tight
               variant="mobile-neutral"
             />
             <ZDAButton
-              clickCallback={() =>
-                clickLink("https://bsky.app/profile/zerodayanubis.com")
-              }
+              clickCallback={() => clickLink(bskyLink)}
               textContent="Bluesky"
               tight
               variant="neutral"
             />
             <ZDAButton
-              clickCallback={() =>
-                clickLink(
-                  "https://instagram.com/zerodayanubis?igshid=OGQ5ZDc2ODk2ZA=="
-                )
-              }
+              clickCallback={() => clickLink(igLink)}
               textContent="Instagram"
               tight
               variant="mobile-neutral"
             />
             <ZDAButton
-              clickCallback={() =>
-                clickLink(
-                  "https://instagram.com/zerodayanubis?igshid=OGQ5ZDc2ODk2ZA=="
-                )
-              }
+              clickCallback={() => clickLink(igLink)}
               textContent="Instagram"
               tight
               variant="neutral"
             />
             <ZDAButton
-              clickCallback={() =>
-                clickLink("https://www.threads.net/@zerodayanubis")
-              }
+              clickCallback={() => clickLink(threadsLink)}
               textContent="Threads"
               tight
               variant="mobile-neutral"
             />
             <ZDAButton
-              clickCallback={() =>
-                clickLink("https://www.threads.net/@zerodayanubis")
-              }
+              clickCallback={() => clickLink(threadsLink)}
               textContent="Threads"
               tight
               variant="neutral"
             />
             <ZDAButton
-              clickCallback={() => clickLink("https://tinyurl.com/ZDACara")}
+              clickCallback={() => clickLink(caraLink)}
               textContent="Cara"
               tight
               variant="mobile-neutral"
             />
             <ZDAButton
-              clickCallback={() => clickLink("https://tinyurl.com/ZDACara")}
+              clickCallback={() => clickLink(caraLink)}
               textContent="Cara"
               tight
               variant="neutral"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -45,6 +45,22 @@ export const switchPage = (
 };
 
 /**
+ * Perform a hard redirect to a link's path, bypassing the website.
+ * @param path external link's path
+ */
+export const redirectToLink = (path: string) => {
+  window.location.replace(path);
+};
+
+/**
+ * Gets the subdomain from the current hostname.
+ * @returns subdomain (or just domain if none) as string
+ */
+export const getSubdomain = () => {
+  return window.location.hostname.split(".", 1)[0];
+};
+
+/**
  * On image load, show the base img and hide the blur img.
  * @param imgId unique className id of img
  */
@@ -72,4 +88,13 @@ export const scrollToSection = (idOfSection: string) => {
  */
 export const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
+};
+
+/**
+ * Return string/word capitalized.
+ * @param str a word to capitalize
+ * @returns capitalized word (string)
+ */
+export const capitalizeString = (str: string) => {
+  return str.charAt(0).toLocaleUpperCase() + str.slice(1);
 };

--- a/src/links.ts
+++ b/src/links.ts
@@ -1,0 +1,18 @@
+/* GLOBALLY USED LINKS */
+// Redirects and ZDA-related links
+export const commFormLink = "https://tally.so/r/w52VP6";
+export const commInfoLink = "https://drive.google.com/file/d/1AQ-RCfIHOP77tW5D28NNaFl2wvkkBqUz/view?usp=sharing";
+export const privacyLink = "https://drive.google.com/file/d/13cQYluebHO55mcJ057e2Z2IMw3ceW5rM/view?usp=sharing";
+export const zdaWorksLink = "https://www.zda.works/";
+// Social Media
+export const bskyLink = "https://bsky.app/profile/zerodayanubis.com";
+export const igLink = "https://instagram.com/zerodayanubis?igshid=OGQ5ZDc2ODk2ZA==";
+export const threadsLink = "https://www.threads.net/@zerodayanubis";
+export const caraLink = "https://cara.app/zerodayanubis/";
+// Prints/Support
+export const printShopLink = "https://www.inprnt.com/gallery/zerodayanubis/";
+export const kofiLink = "https://ko-fi.com/zerodayanubis";
+export const payPalLink = "https://www.paypal.com/ncp/payment/AGHU59JTKAC66";
+export const venmoLink = "https://account.venmo.com/u/somgye";
+// Misc.
+export const discordLink = "https://discordapp.com/users/193548282264420354";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import ErrorPage from "./pages/ErrorPage.tsx";
 import { RecoilRoot } from "recoil";
 import App from "./App.tsx";
 import "./index.css";
+import RedirectStub from "./RedirectStub.tsx";
+import { commFormLink, commInfoLink, privacyLink } from "./links.ts";
 
 /* FONTSOURCE IMPORTS */
 // import "@fontsource/outfit/100.css"; // ? Titles/Buttons
@@ -42,38 +44,65 @@ import "@fontsource/urbanist/400.css";
 // import "@fontsource/urbanist/800.css";
 // import "@fontsource/urbanist/900.css";
 
-const router = createBrowserRouter([
+const routes = [
   {
     path: "/",
-    element: <App route="" />,
-    errorElement: <ErrorPage />,
+    route: "",
+    redirect: "",
   },
   {
     path: "/portfolio",
-    element: <App route="portfolio" />,
-    errorElement: <ErrorPage />,
+    route: "portfolio",
+    redirect: "",
   },
   {
     path: "/commissions",
-    element: <App route="commissions" />,
-    errorElement: <ErrorPage />,
+    route: "commissions",
+    redirect: "",
   },
   {
     path: "/about",
-    element: <App route="about" />,
-    errorElement: <ErrorPage />,
+    route: "about",
+    redirect: "",
   },
   {
     path: "/logo",
-    element: <App route="logo" />,
-    errorElement: <ErrorPage />,
+    route: "logo",
+    redirect: "",
   },
   {
     path: "/examples",
-    element: <App route="examples" />,
-    errorElement: <ErrorPage />,
+    route: "examples",
+    redirect: "",
   },
-]);
+  {
+    path: "/form",
+    route: "form",
+    redirect: commFormLink,
+  },
+  {
+    path: "/info",
+    route: "info",
+    redirect: commInfoLink,
+  },
+  {
+    path: "/privacy",
+    route: "privacy",
+    redirect: privacyLink,
+  },
+];
+const routerRoutes = routes.map((route) => { // ? dynamically map routes so that redirects skip App
+  return {
+    path: route.path,
+    element: route.redirect ? (
+      <RedirectStub redirectPath={route.redirect} />
+    ) : (
+      <App route={route.route} routes={routes} />
+    ),
+    errorElement: <ErrorPage />,
+  };
+});
+const router = createBrowserRouter(routerRoutes);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <>

--- a/src/pages/CommissionsPage.tsx
+++ b/src/pages/CommissionsPage.tsx
@@ -33,6 +33,7 @@ import {
 import PagePromos from "../components/PagePromos";
 import { commsOpenAtom } from "../states/commsAtom";
 import { downArrowBigIcon, rightArrowBigIcon } from "../icons";
+import { commFormLink, commInfoLink } from "../links";
 
 const CommissionsPage = () => {
   const theme = useRecoilValue(themeAtom);
@@ -49,9 +50,7 @@ const CommissionsPage = () => {
   const [formVisible, setFormVisible] = React.useState(false);
   const [formLoading, setFormLoading] = React.useState(false);
   const [formScroll, setFormScroll] = React.useState(false);
-  const formLink = "https://tinyurl.com/ZDACommForm";
   const formSection = "comm-form-section";
-  const infoLink = "https://tinyurl.com/ZDACommInfo8";
   const compareMap = ["solitudeType", "peaceType"];
   const [currentCompare, setCompare] = React.useState(compareMap[0]);
 
@@ -117,7 +116,7 @@ const CommissionsPage = () => {
           For full commission information, click{" "}
           <p
             className="home-page-text-link inline-block italic font-semibold text-zdaRedpink-650 dark:text-zdaRed-600 hover:text-slate-700 dark:hover:text-slate-300 active:text-slate-400 dark:active:text-slate-400 border-b border-solid border-transparent hover:border-zdaRedpink-650 dark:hover:border-zdaRed-600 motion-safe:transition-colors motion-safe:duration-300 ease-out cursor-pointer"
-            onClick={() => clickLink(infoLink)}
+            onClick={() => clickLink(commInfoLink)}
           >
             here
           </p>
@@ -203,7 +202,7 @@ const CommissionsPage = () => {
               <>
                 <div className="block md:hidden">
                   <ZDAButton
-                    clickCallback={() => clickLink(formLink)}
+                    clickCallback={() => clickLink(commFormLink)}
                     textContent="Commission Form"
                     variant="mobile"
                   />
@@ -335,7 +334,7 @@ const CommissionsPage = () => {
               <>
                 <div className="block md:hidden">
                   <ZDAButton
-                    clickCallback={() => clickLink(formLink)}
+                    clickCallback={() => clickLink(commFormLink)}
                     textContent="Commission Form"
                     variant="mobile"
                   />
@@ -474,7 +473,7 @@ const CommissionsPage = () => {
               <>
                 <div className="block md:hidden">
                   <ZDAButton
-                    clickCallback={() => clickLink(formLink)}
+                    clickCallback={() => clickLink(commFormLink)}
                     textContent="Commission Form"
                     variant="mobile"
                   />
@@ -712,7 +711,7 @@ const CommissionsPage = () => {
           />
           {/* Mobile Only - Open form in new tab */}
           <ZDAButton
-            clickCallback={() => clickLink(formLink)}
+            clickCallback={() => clickLink(commFormLink)}
             textContent="Commissions Form"
             variant="mobile"
           />
@@ -725,7 +724,7 @@ const CommissionsPage = () => {
           {/* Embedded Commissions Form */}
           {formVisible && (
             <object
-              data={formLink}
+              data={commFormLink}
               type="text/html"
               style={{
                 width: "100%",

--- a/src/pages/ExamplesPage.tsx
+++ b/src/pages/ExamplesPage.tsx
@@ -22,6 +22,7 @@ import {
   photosCommissionsCoalesce,
   photosCommissionsVectorize,
 } from "../lightboxInfo";
+import { zdaWorksLink } from "../links";
 
 const ExamplesPage = () => {
   const currentYear = new Date().getFullYear();
@@ -304,7 +305,7 @@ const ExamplesPage = () => {
           close={() => setIdx_coalesce(-1)}
         />
         <a
-          href="https://www.zda.works/"
+          href={zdaWorksLink}
           className="md:col-span-3 pt-4 text-sm text-gray-700 dark:text-gray-400 select-none"
           target="_blank"
           rel="noopener noreferrer"

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -28,6 +28,7 @@ import { MdClosedCaption, MdClosedCaptionDisabled } from "react-icons/md";
 import { IoMdCloseCircle } from "react-icons/io";
 import JumpToNav from "../components/JumpToNav";
 import ZDAButton from "../components/ZDAButton";
+import { kofiLink } from "../links";
 
 const PortfolioPage = () => {
   const [idx_posters1, setIdx_posters1] = React.useState(-1);
@@ -1402,11 +1403,11 @@ const PortfolioPage = () => {
           of my art:
         </span>
         <ZDAButton
-          clickCallback={() => clickLink("https://ko-fi.com/zerodayanubis")}
+          clickCallback={() => clickLink(kofiLink)}
           textContent="Downloads and Support"
         />
         <ZDAButton
-          clickCallback={() => clickLink("https://ko-fi.com/zerodayanubis")}
+          clickCallback={() => clickLink(kofiLink)}
           textContent="Downloads and Support"
           variant="mobile"
         />

--- a/src/sections/Footer/Footer.tsx
+++ b/src/sections/Footer/Footer.tsx
@@ -13,6 +13,19 @@ import { chatIcon, emailIcon, privacyDocIcon } from "../../icons";
 import { clickEmail, clickLink, switchPage } from "../../helpers";
 import { pageAtom } from "../../states/pageAtom";
 import { altLongTextLogo, altZDALogoSm, altZDAWorksLogo } from "../../AltText";
+import {
+  bskyLink,
+  caraLink,
+  discordLink,
+  igLink,
+  kofiLink,
+  payPalLink,
+  printShopLink,
+  privacyLink,
+  threadsLink,
+  venmoLink,
+  zdaWorksLink,
+} from "../../links";
 
 const Footer = () => {
   const theme = useRecoilValue(themeAtom);
@@ -36,7 +49,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://bsky.app/profile/zerodayanubis.com"
+                  href={bskyLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -51,7 +64,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://instagram.com/zerodayanubis?igshid=OGQ5ZDc2ODk2ZA=="
+                  href={igLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -66,7 +79,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://www.threads.net/@zerodayanubis"
+                  href={threadsLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -81,7 +94,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://tinyurl.com/ZDACara"
+                  href={caraLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -103,7 +116,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://tinyurl.com/ZDAPrints"
+                  href={printShopLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -118,7 +131,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://ko-fi.com/zerodayanubis"
+                  href={kofiLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -133,7 +146,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://www.paypal.com/ncp/payment/AGHU59JTKAC66"
+                  href={payPalLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -148,7 +161,7 @@ const Footer = () => {
                       : "footer-link-animated ") +
                     "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out select-none"
                   }
-                  href="https://account.venmo.com/u/somgye"
+                  href={venmoLink}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -166,7 +179,7 @@ const Footer = () => {
             </h3>
             <a
               className="select-none"
-              href="https://www.zda.works/"
+              href={zdaWorksLink}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -187,7 +200,7 @@ const Footer = () => {
             </h3>
             <a
               className="inline-flex justify-start items-center gap-2 text-sm text-zdaRed-400 hover:text-zdaRedpink-800 active:text-zdaRedpink-1000 dark:text-gray-400/80 dark:hover:text-zdaRed-500 dark:active:text-zdaRed-500/70 select-none"
-              href="http://tinyurl.com/ZDAPrivacy2"
+              href={privacyLink}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -227,7 +240,7 @@ const Footer = () => {
               />
             </div>
             <a
-              href="https://www.zda.works/"
+              href={zdaWorksLink}
               className="text-sm text-gray-700 dark:text-gray-400 sm:ml-6 mt-[27px] sm:mt-0 select-none"
               target="_blank"
               rel="noopener noreferrer"
@@ -250,9 +263,7 @@ const Footer = () => {
               className="inline-flex justify-between items-center px-4 py-2 h-min rounded-3xl bg-gray-500/15 active:bg-gray-500/60 hover:bg-gray-500/40 dark:bg-neutral-500/10 dark:active:bg-neutral-500/45 dark:hover:bg-neutral-500/25 text-gray-800 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100 text-[0] lg:text-sm motion-safe:transition-colors motion-safe:duration-300 ease-out select-none"
               aria-label="Message"
               title="Message me on Discord"
-              onClick={() =>
-                clickLink("https://discordapp.com/users/193548282264420354")
-              }
+              onClick={() => clickLink(discordLink)}
             >
               <span className="mt-[1px] mr-0 lg:mr-6">{chatIcon}</span>
               Message


### PR DESCRIPTION
### Description
Resolves #52 by refactoring the router to map through an array of routes and adding additional routes:
- /form: Commissions Request Form
- /info: Commissions Info
- /privacy: ZDAWebsite Privacy Policy

This also:
- Updates the comm form link to point to the newer form based in Tally, instead of the Google Forms one
- Moves all of the link strings to a global links file to consolidate them


#### NOTE: I was originally going to replace the tinyurls altogether with a hosted redirect through these routes, but decided against it, since:
- The user would still have to load the index and main scripts and dependencies to get to the RedirectStub (which does bypass App)
- Tinyurl is fast and reliable and the redirect step in ZDAWebsite does add a little bit of loading time