### PR TITLE
Fix: Working text wrap for SectionIndicator in Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "dependencies": {
         "@emotion/react": "~11.11.3",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/components/SectionIndicator.tsx
+++ b/src/components/SectionIndicator.tsx
@@ -12,7 +12,7 @@ const SectionIndicator = ({ sectionName, id }: props) => {
       id={id ? id : sectionName}
     >
       <div className="left-fading-line w-1/2 lg:w-16 2xl:w-12 h-px my-1 rounded-2xl bg-gradient-to-r from-slate-100 to-slate-500 dark:from-gray-800 dark:to-gray-400" />
-      <div className="mid-line w-auto mx-3 2xl:mx-2 text-xl font-extrabold text-nowrap text-slate-600 dark:text-slate-300 select-none">
+      <div className="mid-line w-auto mx-3 2xl:mx-2 text-xl font-extrabold text-nowrap whitespace-nowrap text-slate-600 dark:text-slate-300 select-none">
         {sectionName}
       </div>
       <div className="right-fading-line w-1/2 lg:w-full h-px my-1 rounded-2xl bg-gradient-to-l from-slate-200 to-slate-500 dark:from-gray-900 dark:to-gray-400" />

--- a/src/components/SectionIndicator.tsx
+++ b/src/components/SectionIndicator.tsx
@@ -12,7 +12,7 @@ const SectionIndicator = ({ sectionName, id }: props) => {
       id={id ? id : sectionName}
     >
       <div className="left-fading-line w-1/2 lg:w-16 2xl:w-12 h-px my-1 rounded-2xl bg-gradient-to-r from-slate-100 to-slate-500 dark:from-gray-800 dark:to-gray-400" />
-      <div className="mid-line w-auto mx-3 2xl:mx-2 text-xl font-extrabold text-nowrap whitespace-nowrap text-slate-600 dark:text-slate-300 select-none">
+      <div className="mid-line w-auto mx-3 2xl:mx-2 mb-[0.125rem] text-xl font-extrabold text-nowrap whitespace-nowrap text-slate-600 dark:text-slate-300 select-none">
         {sectionName}
       </div>
       <div className="right-fading-line w-1/2 lg:w-full h-px my-1 rounded-2xl bg-gradient-to-l from-slate-200 to-slate-500 dark:from-gray-900 dark:to-gray-400" />


### PR DESCRIPTION
### Description
Resolves #57 by:
- Adding whitespace nowrap rule (that works in both Chrome and Firefox)
- Fixing the center alignment, of side lines relative to text middle, by using margin-bottom of 2px (0.125rem)