### PR TITLE
Chore: Remove Mastodon verification link

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,9 +33,6 @@
       <span class="loadingspan">Loading ZDA Website...</span>
     </div>
     <div id="root"></div>
-    <a rel="me" href="https://ohai.social/@ZeroDayAnubis" style="display: none"
-      >Mastodon</a
-    >
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite --open",


### PR DESCRIPTION
I deleted my Mastodon account, so no need for verification link anymore.