### PR TITLE
Fix: Use Better Gradient Transition for Dark Footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "2.1.3",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "2.1.3",
+      "version": "2.1.5",
       "dependencies": {
         "@emotion/react": "~11.11.3",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/sections/Footer/Footer.tsx
+++ b/src/sections/Footer/Footer.tsx
@@ -33,7 +33,7 @@ const Footer = () => {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="w-full z-30 bottom-0 left-0 mt-auto bg-gradient-to-b from-zdaRedpink-400/5 dark:from-stone-700/5 dark:to-zdaRedpink-700/5 text-gray-700 dark:text-gray-200 text-base border-t border-gray-200/50 dark:border-stone-800/10 rounded-md">
+    <footer className="w-full z-30 bottom-0 left-0 mt-auto bg-gradient-to-b from-zdaRedpink-400/5 dark:from-zdaRedpink-700/0 dark:to-zdaRedpink-700/5 text-gray-700 dark:text-gray-200 text-base border-t border-gray-200/50 dark:border-stone-800/10 rounded-md">
       <div className="px-3 md:px-7 lg:px-10 py-8 mx-auto">
         <div className="flex flex-wrap md:text-left text-center order-first">
           <div className="lg:w-1/4 md:w-1/2 w-full px-4">


### PR DESCRIPTION
### Description
This resolves #60 by using zda-Redpink for the dark-mode footer transition instead of Stone. 
**NOTE:** This makes the top border now visible rather than blended in, but for dark-mode it works, since it helps delineate the bottom section.