### PR TITLE
Feature: Update links to go zda works and move away from WWW

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@
 ------
 ##### Examples Page
 - To see the Commission Tiers Examples page you can do one of the following:
-  - Go to the `/examples` route (or https://www.zerodayanubis.com/examples)
+  - Go to the `/examples` route (or https://zerodayanubis.com/examples)
   - Run `npm run examples`
   - Scroll down to the footer and click the "Thank you for visiting!"
 ------
 ##### Logo Page
 - To see the ZDA Logo page you can do one of the following:
-  - Go to the `/logo` route (or https://www.zerodayanubis.com/logo)
+  - Go to the `/logo` route (or https://zerodayanubis.com/logo)
   - Run `npm run logo`
   - Click the **Z** logo in the top banner (left for tablet/desktop, center for phone)
 ------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "dependencies": {
         "@emotion/react": "~11.11.3",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.zerodayanubis.com/</loc>
+    <loc>https://zerodayanubis.com/</loc>
     <lastmod>2024-07-03</lastmod>
   </url>
   <url>
-    <loc>https://www.zerodayanubis.com/portfolio</loc>
+    <loc>https://zerodayanubis.com/portfolio</loc>
     <lastmod>2024-07-03</lastmod>
   </url>
   <url>
-    <loc>https://www.zerodayanubis.com/commissions</loc>
+    <loc>https://zerodayanubis.com/commissions</loc>
     <lastmod>2024-07-03</lastmod>
   </url>
   <url>
-    <loc>https://www.zerodayanubis.com/about</loc>
+    <loc>https://zerodayanubis.com/about</loc>
     <lastmod>2024-07-03</lastmod>
   </url>
   <url>
-    <loc>https://www.zerodayanubis.com/logo</loc>
+    <loc>https://zerodayanubis.com/logo</loc>
     <lastmod>2024-07-03</lastmod>
   </url>
   <url>
-    <loc>https://www.zerodayanubis.com/examples</loc>
+    <loc>https://zerodayanubis.com/examples</loc>
     <lastmod>2024-07-03</lastmod>
   </url>
 </urlset>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,7 +35,7 @@ export const switchPage = (
   } else {
     if (hardUrl) {
       window.location.replace(
-        "https://www.zerodayanubis.com/" + target.toLocaleLowerCase()
+        "https://zerodayanubis.com/" + target.toLocaleLowerCase()
       );
     } else {
       window.history.replaceState({}, "", "/" + target.toLocaleLowerCase());

--- a/src/links.ts
+++ b/src/links.ts
@@ -3,7 +3,7 @@
 export const commFormLink = "https://go.zda.works/commform";
 export const commInfoLink = "https://go.zda.works/comminfo";
 export const privacyLink = "https://go.zda.works/privacyzda";
-export const zdaWorksLink = "https://www.zda.works/";
+export const zdaWorksLink = "https://zda.works/";
 // Social Media
 export const bskyLink = "https://bsky.app/profile/zerodayanubis.com";
 export const igLink = "https://instagram.com/zerodayanubis?igshid=OGQ5ZDc2ODk2ZA==";

--- a/src/links.ts
+++ b/src/links.ts
@@ -5,14 +5,14 @@ export const commInfoLink = "https://go.zda.works/comminfo";
 export const privacyLink = "https://go.zda.works/privacyzda";
 export const zdaWorksLink = "https://zda.works/";
 // Social Media
-export const bskyLink = "https://bsky.app/profile/zerodayanubis.com";
-export const igLink = "https://instagram.com/zerodayanubis?igshid=OGQ5ZDc2ODk2ZA==";
-export const threadsLink = "https://www.threads.net/@zerodayanubis";
-export const caraLink = "https://cara.app/zerodayanubis/";
+export const bskyLink = "https://go.zda.works/bsky";
+export const igLink = "https://go.zda.works/insta";
+export const threadsLink = "https://go.zda.works/threads";
+export const caraLink = "https://go.zda.works/cara";
 // Prints/Support
 export const printShopLink = "https://go.zda.works/prints";
-export const kofiLink = "https://ko-fi.com/zerodayanubis";
-export const payPalLink = "https://www.paypal.com/ncp/payment/AGHU59JTKAC66";
-export const venmoLink = "https://account.venmo.com/u/somgye";
+export const kofiLink = "https://go.zda.works/kofi";
+export const payPalLink = "https://go.zda.works/paypal";
+export const venmoLink = "https://go.zda.works/venmo";
 // Misc.
-export const discordLink = "https://discordapp.com/users/193548282264420354";
+export const discordLink = "https://go.zda.works/discord";


### PR DESCRIPTION
### Description
Resolves #69 by switching over remaining links to go.zda.works shortio links, and removes the unneeded WWW subdomain.
NOTE: left robots.txt alone, as that is already indexed by search engines.