### PR TITLE
Fix: Add Fallback Scroll to Top on Switch Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@emotion/react": "~11.11.3",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/public/loading.css
+++ b/public/loading.css
@@ -35,8 +35,12 @@ div.spinnerbox {
   height: 64px;
   width: 64px;
   animation: rotate_3922 1.2s linear infinite;
-  background-color: #c7002b;
-  background-image: linear-gradient(#ff0037, #c7002b, #ff0048);
+  /* zdaBlue (600) Version */
+  background-color: #0b62ff;
+  background-image: linear-gradient(#2284ff, #0b62ff, #035af7);
+  /* zdaRedpink (700) Version */
+  /* background-color: #c7002b; */
+  /* background-image: linear-gradient(#ff0037, #c7002b, #ff0048); */
   z-index: 999;
 
   &:focus-visible {
@@ -49,8 +53,12 @@ div.spinnerbox span {
   border-radius: 50%;
   height: 100%;
   width: 100%;
-  background-color: #c7002b;
-  background-image: linear-gradient(#ff0037, #c7002b, #ff0048);
+  /* zdaBlue (600) Version */
+  background-color: #0b62ff;
+  background-image: linear-gradient(#2284ff, #0b62ff, #035af7);
+  /* zdaRedpink (700) Version */
+  /* background-color: #c7002b; */
+  /* background-image: linear-gradient(#ff0037, #c7002b, #ff0048); */
 }
 
 div.spinnerbox span:nth-of-type(1) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,7 +28,14 @@ export const switchPage = (
   setPage: (page: string) => void,
   hardUrl: boolean = false
 ) => {
+  /* Reset scroll position to top;
+  if unsuccessful, use smooth scroll after short delay */
   document.body.scrollTop = document.documentElement.scrollTop = 0;
+  const scrollDelay = 220;
+  setTimeout(() => {
+    scrollToTop();
+  }, scrollDelay);
+
   // Set URL to target without refresh
   if (target === "Home") {
     window.history.replaceState({}, "", "/");

--- a/src/sections/Header/Header.tsx
+++ b/src/sections/Header/Header.tsx
@@ -207,7 +207,6 @@ const Header = () => {
                 onClick={() => switchPage("Logo", setPage)}
                 onTouchEnd={() => switchPage("Logo", setPage)}
               />
-              {/* // ? TODO: figure out lag when switching red/blue */}
               <img
                 src={getLogoSrc()}
                 alt={altZDALogoCirc}


### PR DESCRIPTION
### Description:
Resolves #75 
Adds a fallback smooth scroll to top, on delay, when using switchPage() and the document method does not work (like when using Portfolio's JumpToNav and then clicking another page from Header nav).

#### NOTE:
This also fixes an oversight: the loading spinner now has a zdaBlue version as default (kept old zdaRedpink version in CSS, commented out).