### PR TITLE
Feature: Add Writings Page and Update Sitemap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zdawebsite",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zdawebsite",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@emotion/react": "~11.11.3",
         "@emotion/styled": "~11.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zdawebsite",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,26 +2,30 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://zerodayanubis.com/</loc>
-    <lastmod>2024-07-03</lastmod>
+    <lastmod>2025-01-22</lastmod>
   </url>
   <url>
     <loc>https://zerodayanubis.com/portfolio</loc>
-    <lastmod>2024-07-03</lastmod>
+    <lastmod>2025-01-22</lastmod>
   </url>
   <url>
     <loc>https://zerodayanubis.com/commissions</loc>
-    <lastmod>2024-07-03</lastmod>
+    <lastmod>2025-01-22</lastmod>
   </url>
   <url>
     <loc>https://zerodayanubis.com/about</loc>
-    <lastmod>2024-07-03</lastmod>
+    <lastmod>2025-01-09</lastmod>
   </url>
   <url>
     <loc>https://zerodayanubis.com/logo</loc>
-    <lastmod>2024-07-03</lastmod>
+    <lastmod>2025-01-09</lastmod>
   </url>
   <url>
     <loc>https://zerodayanubis.com/examples</loc>
-    <lastmod>2024-07-03</lastmod>
+    <lastmod>2025-01-09</lastmod>
+  </url>
+  <url>
+    <loc>https://zerodayanubis.com/writings</loc>
+    <lastmod>2025-01-24</lastmod>
   </url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ const App = ({ route, routes }: props) => {
 
     // Fallback to Home
     if (!matchedRoute) {
-      console.log("hit fallback");
+      console.log("App: Hit fallback route");
       setPage("Home");
     }
   }, []);

--- a/src/Writings.ts
+++ b/src/Writings.ts
@@ -1,0 +1,100 @@
+/* Source for WritingsPage */
+export type writingsContentsType = {
+  type: string;
+  title: string;
+  content: string;
+  datetime: string;
+  year: number;
+  month: number;
+  day: number;
+  time: string;
+};
+export type writingsType = {
+  section: string;
+  contents: writingsContentsType[];
+};
+export const writings: writingsType[] = [
+  {
+    section: "Poems",
+    contents: [
+      {
+        type: "poem",
+        title: "Nothing At All",
+        content: `Nothing at all
+        I wish I thought
+        Too much, to recall
+        
+        Consumed in thoughts
+        I had it all
+        Only in mind
+        Nothing to recall
+        
+        Nothing at all
+        Matters in these halls
+        Too much, to fall
+        
+        Consumed in memories
+        Bitter and sour
+        Always in mind
+        Dour the tone,
+        Grim the reflection
+        
+        Nothing at all
+        Really matters
+        Too much, to recall.
+        `,
+        datetime: "2025-01-23 1438",
+        year: 2025,
+        month: 1,
+        day: 23,
+        time: "1438",
+      },
+      {
+        type: "poem",
+        title: "Just Testing",
+        content: `Testing,
+        Just a thing to see
+        Does it really work?
+        
+        Not really;
+        Even if you think it did,
+        it was merely a mirage,
+        A meaningless mirage,
+        Just like you.
+        `,
+        datetime: "2025-01-23 2110",
+        year: 2025,
+        month: 1,
+        day: 23,
+        time: "2110",
+      },
+      {
+        type: "poem",
+        title: "Burning Forgiveness",
+        content: `Burned away, tucked away
+It never goes away
+Memories hotter than a searing knife
+It never goes away
+
+Days of wishing
+Wishing it would go away
+When you remember who started it:
+Does everyone deserve forgiveness?
+        `,
+        datetime: "2025-01-26 0850",
+        year: 2025,
+        month: 1,
+        day: 26,
+        time: "0850",
+      },
+    ],
+  },
+  {
+    section: "Ramblings",
+    contents: [],
+  },
+  {
+    section: "Phrases",
+    contents: [],
+  },
+];

--- a/src/components/SectionIndicator.tsx
+++ b/src/components/SectionIndicator.tsx
@@ -2,17 +2,24 @@ import * as React from "react";
 
 type props = {
   sectionName: string;
+  isSmall?: boolean;
   id?: string;
 };
 
-const SectionIndicator = ({ sectionName, id }: props) => {
+const SectionIndicator = ({ sectionName, isSmall, id }: props) => {
   return (
     <div
       className="long-fading-line-container flex flex-row justify-center lg:justify-start items-center w-full my-8 scroll-mt-24"
       id={id ? id : sectionName}
     >
       <div className="left-fading-line w-1/2 lg:w-16 2xl:w-12 h-px my-1 rounded-2xl bg-gradient-to-r from-slate-100 to-slate-500 dark:from-gray-800 dark:to-gray-400" />
-      <div className="mid-line w-auto mx-3 2xl:mx-2 mb-[0.125rem] text-xl font-extrabold text-nowrap whitespace-nowrap text-slate-600 dark:text-slate-300 select-none">
+      <div
+        className={`mid-line w-auto mx-3 2xl:mx-2 mb-[0.125rem] ${
+          isSmall ? "text-base" : "text-xl"
+        } ${
+          isSmall ? "font-semibold" : "font-extrabold"
+        } text-nowrap whitespace-nowrap text-slate-600 dark:text-slate-300 select-none`}
+      >
         {sectionName}
       </div>
       <div className="right-fading-line w-1/2 lg:w-full h-px my-1 rounded-2xl bg-gradient-to-l from-slate-200 to-slate-500 dark:from-gray-900 dark:to-gray-400" />

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -22,33 +22,60 @@ export const clickLink = (linkLocation: string, newTab: boolean = true) => {
  * @param target URL path (Portfolio, Commissions, etc)
  * @param setPage React.useState setter passed in from component
  * @param hardUrl If true, clear subdomain and go direct to root/target
+ * @param scrollFirst If true, do scroll logic first and switch on delay
  */
 export const switchPage = (
   target: string,
   setPage: (page: string) => void,
-  hardUrl: boolean = false
+  hardUrl: boolean = false,
+  scrollFirst: boolean = false
 ) => {
-  /* Reset scroll position to top;
+  if (scrollFirst) {
+    /* Reset scroll position to top;
   if unsuccessful, use smooth scroll after short delay */
-  document.body.scrollTop = document.documentElement.scrollTop = 0;
-  const scrollDelay = 220;
-  setTimeout(() => {
+    document.body.scrollTop = document.documentElement.scrollTop = 0;
     scrollToTop();
-  }, scrollDelay);
 
-  // Set URL to target without refresh
-  if (target === "Home") {
-    window.history.replaceState({}, "", "/");
+    // Do page switch on delay
+    const switchDelay = 350; // ? needs extra delay for this case
+    setTimeout(() => {
+      // Set URL to target without refresh
+      if (target === "Home") {
+        window.history.replaceState({}, "", "/");
+      } else {
+        if (hardUrl) {
+          window.location.replace(
+            "https://zerodayanubis.com/" + target.toLocaleLowerCase()
+          );
+        } else {
+          window.history.replaceState({}, "", "/" + target.toLocaleLowerCase());
+        }
+      }
+      setPage(target);
+    }, switchDelay);
   } else {
-    if (hardUrl) {
-      window.location.replace(
-        "https://zerodayanubis.com/" + target.toLocaleLowerCase()
-      );
+    /* Reset scroll position to top;
+  if unsuccessful, use smooth scroll after short delay */
+    document.body.scrollTop = document.documentElement.scrollTop = 0;
+    const scrollDelay = 220;
+    setTimeout(() => {
+      scrollToTop();
+    }, scrollDelay);
+
+    // Set URL to target without refresh
+    if (target === "Home") {
+      window.history.replaceState({}, "", "/");
     } else {
-      window.history.replaceState({}, "", "/" + target.toLocaleLowerCase());
+      if (hardUrl) {
+        window.location.replace(
+          "https://zerodayanubis.com/" + target.toLocaleLowerCase()
+        );
+      } else {
+        window.history.replaceState({}, "", "/" + target.toLocaleLowerCase());
+      }
     }
+    setPage(target);
   }
-  setPage(target);
 };
 
 /**

--- a/src/index.css
+++ b/src/index.css
@@ -599,6 +599,10 @@ button.yarl__button:focus-visible {
   /* mobile */
   bottom: 2rem;
   right: 2rem;
+  @media (min-width: 640px) { /* sm */
+    bottom: 2rem;
+    right: 1.47rem;
+  }
   @media (min-width: 768px) { /* md */
     bottom: 6.25rem;
     right: 2.5rem;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -76,6 +76,11 @@ const routes = [
     redirect: "",
   },
   {
+    path: "/writings",
+    route: "writings",
+    redirect: "",
+  },
+  {
     path: "/form",
     route: "form",
     redirect: commFormLink,

--- a/src/pages/WritingsPage.tsx
+++ b/src/pages/WritingsPage.tsx
@@ -1,25 +1,46 @@
 import * as React from "react";
 import { useRecoilValue } from "recoil";
-import { colorSchemeAtom, colorSchemes, themeAtom } from "../states/themeAtom";
+import { colorSchemeAtom, colorSchemes } from "../states/themeAtom";
 import SectionIndicator from "../components/SectionIndicator";
 import { writings } from "../Writings";
 
-// TODO: classes for color schemes
+const itemClasses = [
+  {
+    className:
+      "writings-item w-4/5 md:w-3/5 lg:w-1/2 xl:w-2/5 rounded-xl my-4 px-4 py-9 whitespace-pre-line border border-zdaBlue-400 hover:border-zdaBlue-300 dark:border-zdaBlue-600/75 dark:hover:border-zdaBlue-500 drop-shadow-card-sm-light-blue dark:drop-shadow-card-sm-dark-blue hover:drop-shadow-none dark:hover:drop-shadow-none bg-gradient-to-b from-zdaBG-light dark:from-zdaBlue-1000/30 via-zdaBG-lighterCard dark:via-zdaBlue-1000/30 to-zdaBlue-50/75 dark:to-zdaBlue-1000/30 motion-safe:transition-all motion-safe:duration-200 ease-out",
+    colorScheme: colorSchemes[0],
+  },
+  {
+    className:
+      "writings-item w-4/5 md:w-3/5 lg:w-1/2 xl:w-2/5 rounded-xl my-4 px-4 py-9 whitespace-pre-line border border-zdaRedpink-400 hover:border-zdaRedpink-300 dark:border-zdaRedpink-700 dark:hover:border-zdaRedpink-600 drop-shadow-card-sm-light-red dark:drop-shadow-card-sm-dark-red hover:drop-shadow-none dark:hover:drop-shadow-none bg-gradient-to-b from-zdaBG-light dark:from-zdaRedpink-1000/20 via-zdaBG-lighterCard dark:via-zdaRedpink-1000/20 to-zdaRedpink-50/75 dark:to-zdaRedpink-1000/20 motion-safe:transition-all motion-safe:duration-200 ease-out",
+    colorScheme: colorSchemes[1],
+  },
+];
 
 const WritingsPage = () => {
-  const theme = useRecoilValue(themeAtom);
   const colorScheme = useRecoilValue(colorSchemeAtom);
-  const [idx_scheme, setIdx_scheme] = React.useState(0);
+  const evenMargin = " ml-1 sm:ml-4 mr-1 sm:mr-8 md:mr-12 lg:mr-32";
+  const oddMargin = " mr-1 sm:mr-4 ml-1 sm:ml-8 md:ml-12 lg:ml-32";
 
-  React.useEffect(() => {
-    // Update matched scheme index
-    setIdx_scheme(colorSchemes.indexOf(colorScheme));
-  }, [colorScheme]);
+  const getColorSchemeClassName = () => {
+    // Filter on classes for className matching colorScheme
+    const resultObj = itemClasses.filter(
+      (classObj) => classObj.colorScheme === colorScheme
+    );
+    if (resultObj && resultObj.length) {
+      return resultObj[0].className;
+    } else {
+      return itemClasses[0].className;
+    }
+  };
 
   return (
     <div className="writings-page-container w-full flex flex-col justify-center items-center">
-      {writings.map((section) => (
-        <>
+      {writings.map((section, idx) => (
+        <div
+          className="writings-section-wrapper w-full flex flex-col items-center"
+          key={idx}
+        >
           {/* Skip empty sections */}
           {section.contents.length > 0 && (
             <div
@@ -34,11 +55,10 @@ const WritingsPage = () => {
                   .reverse()
                   .map((item, idx) => (
                     <div
-                      className={`writings-item w-4/5 md:w-3/5 lg:w-1/2 xl:w-2/5 rounded-xl my-4 ${
-                        idx % 2 === 0
-                          ? "ml-1 sm:ml-4 mr-1 sm:mr-8 md:mr-12 lg:mr-32"
-                          : "mr-1 sm:mr-4 ml-1 sm:ml-8 md:ml-12 lg:ml-32"
-                      } px-4 py-9 whitespace-pre-line border border-zdaBlue-400 hover:border-zdaBlue-300 dark:border-zdaBlue-600/75 dark:hover:border-zdaBlue-500 drop-shadow-card-sm-light-blue dark:drop-shadow-card-sm-dark-blue hover:drop-shadow-none dark:hover:drop-shadow-none bg-gradient-to-b from-zdaBG-light dark:from-zdaBlue-1000/30 via-zdaBG-lighterCard dark:via-zdaBlue-1000/30 to-zdaBlue-50/75 dark:to-zdaBlue-1000/30 motion-safe:transition-all motion-safe:duration-200 ease-out`}
+                      className={
+                        getColorSchemeClassName() +
+                        `${idx % 2 === 0 ? evenMargin : oddMargin}`
+                      }
                       key={idx}
                     >
                       <p className="writings-item-title -mt-4 mb-4 font-semibold italic">
@@ -55,7 +75,7 @@ const WritingsPage = () => {
               </div>
             </div>
           )}
-        </>
+        </div>
       ))}
     </div>
   );

--- a/src/pages/WritingsPage.tsx
+++ b/src/pages/WritingsPage.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { useRecoilValue } from "recoil";
+import { colorSchemeAtom, colorSchemes, themeAtom } from "../states/themeAtom";
+import SectionIndicator from "../components/SectionIndicator";
+import { writings } from "../Writings";
+
+// TODO: classes for color schemes
+
+const WritingsPage = () => {
+  const theme = useRecoilValue(themeAtom);
+  const colorScheme = useRecoilValue(colorSchemeAtom);
+  const [idx_scheme, setIdx_scheme] = React.useState(0);
+
+  React.useEffect(() => {
+    // Update matched scheme index
+    setIdx_scheme(colorSchemes.indexOf(colorScheme));
+  }, [colorScheme]);
+
+  return (
+    <div className="writings-page-container w-full flex flex-col justify-center items-center">
+      {writings.map((section) => (
+        <>
+          {/* Skip empty sections */}
+          {section.contents.length > 0 && (
+            <div
+              className="writings-section w-full flex flex-col items-center"
+              key={section.section}
+            >
+              <SectionIndicator sectionName={section.section} isSmall />
+              <div className="writings-items-container w-full px-4 flex flex-col justify-between items-center mx-auto">
+                {/* Descending order on contents */}
+                {section.contents
+                  .slice(0)
+                  .reverse()
+                  .map((item, idx) => (
+                    <div
+                      className={`writings-item w-4/5 md:w-3/5 lg:w-1/2 xl:w-2/5 rounded-xl my-4 ${
+                        idx % 2 === 0
+                          ? "ml-1 sm:ml-4 mr-1 sm:mr-8 md:mr-12 lg:mr-32"
+                          : "mr-1 sm:mr-4 ml-1 sm:ml-8 md:ml-12 lg:ml-32"
+                      } px-4 py-9 whitespace-pre-line border border-zdaBlue-400 hover:border-zdaBlue-300 dark:border-zdaBlue-600/75 dark:hover:border-zdaBlue-500 drop-shadow-card-sm-light-blue dark:drop-shadow-card-sm-dark-blue hover:drop-shadow-none dark:hover:drop-shadow-none bg-gradient-to-b from-zdaBG-light dark:from-zdaBlue-1000/30 via-zdaBG-lighterCard dark:via-zdaBlue-1000/30 to-zdaBlue-50/75 dark:to-zdaBlue-1000/30 motion-safe:transition-all motion-safe:duration-200 ease-out`}
+                      key={idx}
+                    >
+                      <p className="writings-item-title -mt-4 mb-4 font-semibold italic">
+                        {item.title}
+                      </p>
+                      <div className="writings-item-content">
+                        {item.content}
+                      </div>
+                      <div className="writings-item-datetime mt-4 -mb-4 font-light italic [word-spacing:0.25rem]">
+                        {item.datetime}
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
+        </>
+      ))}
+    </div>
+  );
+};
+
+export default WritingsPage;

--- a/src/sections/Body/Body.tsx
+++ b/src/sections/Body/Body.tsx
@@ -9,6 +9,7 @@ import HomePage from "../../pages/HomePage";
 import PortfolioPage from "../../pages/PortfolioPage";
 import CommissionsPage from "../../pages/CommissionsPage";
 import AboutPage from "../../pages/AboutPage";
+import WritingsPage from "../../pages/WritingsPage";
 import JumpToTop from "../../components/JumpToTop";
 
 const Body = () => {
@@ -25,6 +26,7 @@ const Body = () => {
           {page === "Portfolio" && <PortfolioPage />}
           {page === "Commissions" && <CommissionsPage />}
           {page === "About" && <AboutPage />}
+          {page === "Writings" && <WritingsPage />}
         </div>
       )}
       {/* Logo Page */}

--- a/src/sections/Footer/Footer.tsx
+++ b/src/sections/Footer/Footer.tsx
@@ -282,7 +282,7 @@ const Footer = () => {
           </div>
           <div className="lg:w-1/4 md:w-1/2 w-full px-4">
             <h2 className="font-medium text-gray-900 dark:text-gray-300 tracking-widest text-sm mb-4 pointer-events-none select-none">
-              EXTRAS
+              MISC.
             </h2>
             <nav className="list-none mb-10">
               <span className="block my-3">
@@ -298,7 +298,19 @@ const Footer = () => {
                   Writings
                 </div>
               </span>
-              {/* TODO: Put in Examples link here */}
+              <span className="block my-3">
+                <div
+                  className={
+                    (theme === "dark"
+                      ? "footer-link-animated-dark "
+                      : "footer-link-animated ") +
+                    "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out cursor-pointer select-none"
+                  }
+                  onClick={() => switchPage("Examples", setPage)}
+                >
+                  Commission Examples
+                </div>
+              </span>
             </nav>
           </div>
           <div className="hidden md:block md:w-1/2 lg:w-1/4 w-full px-4">
@@ -323,10 +335,7 @@ const Footer = () => {
             </a>
           </div>
           <div className="lg:w-1/4 md:w-1/2 w-full px-4">
-            <h3
-              className="font-light text-gray-600 dark:text-gray-400 tracking-wide italic text-[15px] mb-4 cursor-cell select-none"
-              onClick={() => switchPage("Examples", setPage)}
-            >
+            <h3 className="font-light text-gray-600 dark:text-gray-400 tracking-wide italic text-[15px] mb-4 cursor-default select-none">
               Thank you for visiting!
             </h3>
             <a

--- a/src/sections/Footer/Footer.tsx
+++ b/src/sections/Footer/Footer.tsx
@@ -280,6 +280,27 @@ const Footer = () => {
               </span>
             </nav>
           </div>
+          <div className="lg:w-1/4 md:w-1/2 w-full px-4">
+            <h2 className="font-medium text-gray-900 dark:text-gray-300 tracking-widest text-sm mb-4 pointer-events-none select-none">
+              EXTRAS
+            </h2>
+            <nav className="list-none mb-10">
+              <span className="block my-3">
+                <div
+                  className={
+                    (theme === "dark"
+                      ? "footer-link-animated-dark "
+                      : "footer-link-animated ") +
+                    "text-gray-500 hover:text-gray-900 active:text-gray-900 active:font-semibold dark:text-gray-400/90 dark:hover:text-gray-300 dark:active:font-semibold motion-safe:transition-colors motion-safe:duration-200 ease-out cursor-pointer select-none"
+                  }
+                  onClick={() => switchPage("Writings", setPage, false, true)}
+                >
+                  Writings
+                </div>
+              </span>
+              {/* TODO: Put in Examples link here */}
+            </nav>
+          </div>
           <div className="hidden md:block md:w-1/2 lg:w-1/4 w-full px-4">
             <h2 className="font-medium text-gray-900 dark:text-gray-300 tracking-widest text-sm mb-4 pointer-events-none select-none">
               COMPANY

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -110,6 +110,7 @@ export default {
         'card-sm-light-red': '0px 6px 5px #dfa1a340',
         'card-sm-dark': '0px -8px 8px #1f29379a',
         'card-sm-dark-blue': '0px 2px 10px #2284ff1a', // zdaBlue-500
+        'card-sm-dark-red': '0px 2px 10px #ff1a621a', // zdaRedpink-500
         'card-logo-light': '0px 4px 1px #60606040',
         'card-logo-dark': '0px 4px 4px #606060c0',
         'logo-light': '20px 8px 4px #19141a2a',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -109,6 +109,7 @@ export default {
         'card-sm-light-blue': '0px 6px 5px #2284ff24', // zdaBlue-500
         'card-sm-light-red': '0px 6px 5px #dfa1a340',
         'card-sm-dark': '0px -8px 8px #1f29379a',
+        'card-sm-dark-blue': '0px 2px 10px #2284ff1a', // zdaBlue-500
         'card-logo-light': '0px 4px 1px #60606040',
         'card-logo-dark': '0px 4px 4px #606060c0',
         'logo-light': '20px 8px 4px #19141a2a',


### PR DESCRIPTION
### Description:
Resolves #74.
- Adds the "Writings" page, as a route, and to the Footer as a link under the "MISC." section. Currently features poems, but can support short stories, ramblings, phrases, etc. in the future. 
  - Currently shows cards in descending order, and hides unused sections.
- NOTE: needed to add a `scrollFirst` parameter to the `switchPage` function to resolve an issue with page being switched but not getting scrolled to the top. For "Writings" page, needed to scroll up FIRST and then do the page switching, on a delay.
- Fixes the FAB horizontal alignment for when screen is >sm but <md.
- Also gave the "Examples" page a proper link, under the "Writings" page link, as "Commission Examples".
- Updated the sitemap for all of the pages, with a more proper last modified date.
- Improved the log message for when App does not match the route.